### PR TITLE
Expand export ignores and match filenames

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,14 @@
 .tavis.yml export-ignore
-.gitattribute export-ignore
+.gitattributes export-ignore
 .gitignore export-ignore
-.phpcs.xml export-ignore
-.phpstan.neon export-ignore
-.phpunit.xml export-ignore
+phpcs.xml export-ignore
+phpstan.neon export-ignore
+phpunit.xml export-ignore
 .github/ export-ignore
+art/ export-ignore
 tests/ export-ignore
+
+CHANGELOG.md export-ignore
+CODE_OF_CONDUCT.md export-ignore
+CONTRIBUTING.md export-ignore
+README.md export-ignore


### PR DESCRIPTION
Excludes more files which are not relevant for releases and fix non matching filenames.