### PR TITLE
Make log level less strictly expected from psr log

### DIFF
--- a/src/Log/DebugLogger.php
+++ b/src/Log/DebugLogger.php
@@ -23,7 +23,7 @@ class DebugLogger implements LoggerInterface
     }
 
     /**
-     * @param int $level
+     * @param mixed $level
      * @param string $message
      * @param array<string, mixed> $context
      */
@@ -37,11 +37,12 @@ class DebugLogger implements LoggerInterface
     }
 
     /**
+     * @param mixed $level
      * @param array<string, mixed> $context
      * @return array<string, mixed>
      * @throws Exception
      */
-    private function buildRecord(int $level, string $message, array $context = []): array
+    private function buildRecord($level, string $message, array $context = []): array
     {
         if (array_key_exists('error', $context)) {
             /** @var Throwable $error */


### PR DESCRIPTION
### Description

Running the 0.7.2 with -vvv fails:
```
 Uncaught TypeError: Argument 1 passed to Icanhazstring\Composer\Unused\Log\DebugLogger::buildRecord() must be of the type int, string given, called in vendor/icanhazstring/composer-unused/src/Log/DebugLogger.php on line 33 and defined in vendor/icanhazstring/composer-unused/src/Log/DebugLogger.php:44
Stack trace:
#0 vendor/icanhazstring/composer-unused/src/Log/DebugLogger.php(33): Icanhazstring\Composer\Unused\Log\DebugLogger->buildRecord('info', 'version', Array)
#1 phar:///usr/local/bin/composer/vendor/psr/log/Psr/Log/LoggerTrait.php(114): Icanhazstring\Composer\Unused\Log\DebugLogger->log('info', 'version', Array)
#2 vendor/icanhazstring/composer-unused/src/Command/UnusedCommand.php(274): Icanhazstring\Composer\Unused\Log\DebugLogger->info('version', Array)
#3 in vendor/icanhazstring/composer-unused/src/Log/DebugLogger.php on line 44
```

That is due to the constants exposed from psr/log are strings
```
<?php

namespace Psr\Log;

/**
 * Describes log levels.
 */
class LogLevel
{
    const EMERGENCY = 'emergency';
    const ALERT     = 'alert';
    const CRITICAL  = 'critical';
    const ERROR     = 'error';
    const WARNING   = 'warning';
    const NOTICE    = 'notice';
    const INFO      = 'info';
    const DEBUG     = 'debug';
}
```
The psr logger interface expects mixed levels:
```
<?php

namespace Psr\Log;

/**
 * Describes a logger instance.
 *
 * The message MUST be a string or object implementing __toString().
 *
 * The message MAY contain placeholders in the form: {foo} where foo
 * will be replaced by the context data in key "foo".
 *
 * The context array can contain arbitrary data. The only assumption that
 * can be made by implementors is that if an Exception instance is given
 * to produce a stack trace, it MUST be in a key named "exception".
 *
 * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
 * for the full interface specification.
 */
interface LoggerInterface
{
    /**
     * [...]
     */

    /**
     * Logs with an arbitrary level.
     *
     * @param mixed   $level
     * @param string  $message
     * @param mixed[] $context
     *
     * @return void
     *
     * @throws \Psr\Log\InvalidArgumentException
     */
    public function log($level, $message, array $context = array());
}
```
And the debug logger builds records expecting the level to be an int.

### Checklist
* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
