### PR TITLE
Fix missing Composer\Console\Application

### DIFF
--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  run:
+  validate-code:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -32,5 +32,9 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
 
-      - name: check
+      - name: Code check
         run: composer check
+
+      - name: Check unused dependencies
+        run: bin/composer-unused
+

--- a/.github/workflows/validate-phar.yml
+++ b/.github/workflows/validate-phar.yml
@@ -1,0 +1,36 @@
+name: PHP Composer
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate-phar:
+    runs-on: ubuntu-latest
+    name: Validate phar package
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+          ini-values: phar.readonly=false
+
+      - name: Composer install
+        run: composer install --no-dev --prefer-dist
+
+      - name: Download humbug/box
+        run: curl -OL https://github.com/humbug/box/releases/download/3.8.3/box.phar > box.phar
+
+      - name: Compile phar
+        run: php box.phar compile
+
+      - name: Run phar against code
+        run: php build/composer-unused.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.7.2] - 2020-05-19
 ### Added
 - Added `phpspec/prophecy-phpunit` to remove deprecations warnings of `prophecy()` with `phpunit/phpunit:^9.0`
 - Added support for composer 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Added workflow to verify integrity of build `phar` file
+- Added self unused dependency check using `bin/composer-unused`
+### Changed
+- Readded `composer/composer` into root requirements as its required to run `bin/composer-unused`
+
 ## [0.7.2] - 2020-05-19
 ### Added
 - Added `phpspec/prophecy-phpunit` to remove deprecations warnings of `prophecy()` with `phpunit/phpunit:^9.0`

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=7.3",
         "ext-json": "*",
         "composer-plugin-api": "^1.1 || ^2.0",
+        "composer/composer": "^1.1 || ^2.0@dev",
         "nikic/php-parser": "^4.2",
         "psr/container": "^1.0",
         "psr/log": "^1.1",
@@ -27,7 +28,6 @@
     },
     "require-dev": {
         "ext-zend-opcache": "*",
-        "composer/composer": "^1.0 || ^2.0@dev",
         "jangregor/phpstan-prophecy": "^0.6.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^0.12.14",

--- a/src/Command/UnusedCommand.php
+++ b/src/Command/UnusedCommand.php
@@ -88,6 +88,7 @@ class UnusedCommand extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = ($this->symfonyStyleFactory)($input, $output);
+        /** @var Composer|null $composer */
         $composer = $this->getComposer();
 
         if ($composer === null) {


### PR DESCRIPTION
This should solve #82 as it was missing the `composer/composer` requirement.
Also added another workflow to verify that the build `.phar` file is working properly.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you successfully ran tests with your changes locally?
