### PR TITLE
Enhancement: Implement InstanceofStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Added an `InstanceofStrategy` which detects usages in `instanceof` expressions [#100](https://github.com/composer-unused/composer-unused/pull/100)
 ### Fixed
 - Fixed an issue where `ext-ds` classes where not recognized as used [#88](https://github.com/composer-unused/composer-unused/pull/88)
 - Fixed an issue where `extends` and `implements` of FQN was not markes as used [#90](https://github.com/composer-unused/composer-unused/pull/90)

--- a/src/Parser/PHP/Factory/NodeVisitorFactory.php
+++ b/src/Parser/PHP/Factory/NodeVisitorFactory.php
@@ -9,6 +9,7 @@ use Icanhazstring\Composer\Unused\Parser\PHP\NodeVisitor;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\ClassConstStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\ExtendsParseStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\ImplementsParseStrategy;
+use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\InstanceofStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\NewParseStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\PhpExtensionStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\StaticParseStrategy;
@@ -31,6 +32,7 @@ class NodeVisitorFactory
             ),
             new ExtendsParseStrategy(),
             new ImplementsParseStrategy(),
+            new InstanceofStrategy(),
         ], $container->get(ErrorHandlerInterface::class));
     }
 }

--- a/src/Parser/PHP/Strategy/InstanceofStrategy.php
+++ b/src/Parser/PHP/Strategy/InstanceofStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Icanhazstring\Composer\Unused\Parser\PHP\Strategy;
+
+use PhpParser\Node;
+
+final class InstanceofStrategy implements ParseStrategyInterface
+{
+    public function meetsCriteria(Node $node): bool
+    {
+        if (!$node instanceof Node\Expr\Instanceof_) {
+            return false;
+        }
+
+        if (!$node->class instanceof Node\Name) {
+            return false;
+        }
+
+        return $node->class->isFullyQualified() || $node->class->isQualified();
+    }
+
+    /**
+     * @param Node&Node\Expr\Instanceof_ $node
+     * @return array<string>
+     */
+    public function extractNamespaces(Node $node): array
+    {
+        /** @var Node\Name $class */
+        $class = $node->class;
+
+        return [
+            $class->toString(),
+        ];
+    }
+}

--- a/tests/Integration/Parser/PHP/NodeVisitorTest.php
+++ b/tests/Integration/Parser/PHP/NodeVisitorTest.php
@@ -10,6 +10,7 @@ use Icanhazstring\Composer\Unused\Parser\PHP\NodeVisitor;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\ClassConstStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\ExtendsParseStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\ImplementsParseStrategy;
+use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\InstanceofStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\NewParseStrategy;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\ParseStrategyInterface;
 use Icanhazstring\Composer\Unused\Parser\PHP\Strategy\PhpExtensionStrategy;
@@ -177,7 +178,15 @@ class NodeVisitorTest extends TestCase
                 ],
                 'inputFile' => ASSET_DIR . '/TestFiles/ClassImplements.php',
                 'strategy' => new ImplementsParseStrategy()
-            ]
+            ],
+            'Instanceof' => [
+                'expectedUseNamespaces' => [
+                    'Foo\Bar\Qux',
+                    'Foo\Bar\Quz',
+                ],
+                'inputFile' => ASSET_DIR . '/TestFiles/Instanceof.php',
+                'strategy' => new InstanceofStrategy(),
+            ],
         ];
     }
 

--- a/tests/assets/TestFiles/Instanceof.php
+++ b/tests/assets/TestFiles/Instanceof.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Foo\Bar {
+    class Baz {}
+    class Qux {}
+    class Quz {}
+    class Corge {}
+}
+
+namespace {
+
+//    // https://github.com/composer-unused/composer-unused/pull/100#discussion_r506167242
+//
+//    use Foo\Bar;
+//
+//    if ($foo instanceof Bar\Baz) {
+//        // usage should be detected because class is a name, relative to imported namespace
+//    }
+
+    if ($foo instanceof Foo\Bar\Qux) {
+        // usage should be detected because class is a fully-qualified name used in the root namespace
+    }
+
+    if ($foo instanceof \Foo\Bar\Quz) {
+        // usage should be detected because class is a fully-qualified name relative to the root namespace
+    }
+
+    $name = 'Foo\Bar\Corge';
+
+    if ($foo instanceof $name) {
+        // usage should not be detected because class is a variable expression
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

@OskarStark and I ran into an issue in a project that requires `psr/http-message`, and where we use

```php
use Psr/Http;

if ($response instanceof Http\Message\ResponseInterface) {
}
```

However, running

```
$ composer-unused
```

results in `psr/http-message` not being used, so I figured I take a look.

Does that make sense?
