### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,35 @@ Thank you for considering contributing to this package!
 
 ## Steps to contribute
 
+### Installation
+
 1. Fork the repository
-2. `git clone yourname/composer-unsed`
-3. Make your changes
-4. Run `composer check`
-5. Create your Pull-Request
+2. `git clone yourname/composer-unused`
+3. Download the [ext-ds extension](https://pecl.php.net/package/ds/) and make sure it is enabled in php.ini using the [installation instructions](https://github.com/php-ds/ext-ds)
+    
+    a. If you are on Windows, place the DLL file in the php/ext folder in your *ampp directory
+
+4. Download the [ext-zend-opcache extension](https://pecl.php.net/package/ZendOpcache) tgz file and compile it and make sure it is enabled in php.ini using the [installation instructions](https://github.com/zendtech/ZendOptimizerPlus)
+    
+    - Windows users
+
+        1. Download a [pre-compiled DLL file](https://windows.php.net/downloads/pecl/releases/opcache/) 
+
+        2. Place the DLL file in the php/ext folder in your *ampp directory
+        
+        3. Run the following lines:
+        ```
+        zend_extension=php_opcache.dll
+        opcache.enable=On
+        opcache.enable_cli=On
+        ```
+5. Run `composer install`
+
+### Submitting Changes
+
+6. Make your changes
+7. Run `composer check`
+8. Create your Pull-Request
 
 ## Check your changes against local projects
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for considering contributing to this package!
 2. `git clone yourname/composer-unused`
 3. Download the [ext-ds extension](https://pecl.php.net/package/ds/) and make sure it is enabled in php.ini using the [installation instructions](https://github.com/php-ds/ext-ds)
     
-    a. If you are on Windows, place the DLL file in the php/ext folder in your *ampp directory
+   - Windows users - Place the DLL file in the php/ext folder in your *ampp directory
 
 4. Download the [ext-zend-opcache extension](https://pecl.php.net/package/ZendOpcache) tgz file and compile it and make sure it is enabled in php.ini using the [installation instructions](https://github.com/zendtech/ZendOptimizerPlus)
     
@@ -27,6 +27,14 @@ Thank you for considering contributing to this package!
         opcache.enable_cli=On
         ```
 5. Run `composer install`
+
+### Setting up Docker
+
+1. Run `docker-composer -d`
+2. Use the corresponding created containers
+    - composer-unused-7.3
+    - composer-unused-7.4
+    - composer-unused-8.0
 
 ### Submitting Changes
 


### PR DESCRIPTION
I updated the Contributing document to include details about dependencies that can't be installed with `composer install`. 

* Add more steps - extension installation and `composer install` steps - to Steps to Contribute
* Divide into two stages, Installation and Submitting Changes
* Fix typo in step 2

**Closes #120**

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->