### PR TITLE
Added pattern exclusion support for "-implementation" packages

### DIFF
--- a/src/Command/FilterDependencyCollectionCommand.php
+++ b/src/Command/FilterDependencyCollectionCommand.php
@@ -10,23 +10,34 @@ use function array_merge;
 
 final class FilterDependencyCollectionCommand
 {
-    private const GLOBAL_EXCLUSION = [
-        'composer-plugin-api',
+    private const GLOBAL_NAMED_EXCLUSION = [
+        'composer-plugin-api'
+    ];
+
+    private const GLOBAL_PATTERN_EXCLUSION = [
+        '/-implementation$/i'
     ];
 
     /** @var DependencyCollection */
     private $requiredDependencyCollection;
     /** @var array<string> */
     private $namedExclusion;
+    /** @var array<string> */
+    private $patternExclusion;
 
     /**
      * @param DependencyCollection $requiredDependencyCollection
      * @param array<string> $namedExclusion
+     * @param array<string> $patternExclusion
      */
-    public function __construct(DependencyCollection $requiredDependencyCollection, array $namedExclusion)
-    {
+    public function __construct(
+        DependencyCollection $requiredDependencyCollection,
+        array $namedExclusion = [],
+        array $patternExclusion = []
+    ) {
         $this->requiredDependencyCollection = $requiredDependencyCollection;
-        $this->namedExclusion = array_merge(self::GLOBAL_EXCLUSION, $namedExclusion);
+        $this->namedExclusion = array_merge(self::GLOBAL_NAMED_EXCLUSION, $namedExclusion);
+        $this->patternExclusion = array_merge(self::GLOBAL_PATTERN_EXCLUSION, $patternExclusion);
     }
 
     public function getRequiredDependencyCollection(): DependencyCollection
@@ -40,5 +51,13 @@ final class FilterDependencyCollectionCommand
     public function getNamedExclusion(): array
     {
         return $this->namedExclusion;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getPatternExclusion(): array
+    {
+        return $this->patternExclusion;
     }
 }

--- a/src/Command/Handler/CollectFilteredDependenciesCommandHandler.php
+++ b/src/Command/Handler/CollectFilteredDependenciesCommandHandler.php
@@ -12,9 +12,23 @@ final class CollectFilteredDependenciesCommandHandler
     public function collect(FilterDependencyCollectionCommand $command): DependencyCollection
     {
         $namedExclusion = $command->getNamedExclusion();
+        $patternExclusion = $command->getPatternExclusion();
 
-        return $command->getRequiredDependencyCollection()->filter(static function ($dependency) use ($namedExclusion) {
-            return !in_array($dependency->getName(), $namedExclusion);
+        return $command->getRequiredDependencyCollection()->filter(static function ($dependency) use (
+            $namedExclusion,
+            $patternExclusion
+        ) {
+            if (in_array($dependency->getName(), $namedExclusion)) {
+                return false;
+            }
+
+            foreach ($patternExclusion as $exclusion) {
+                if (preg_match($exclusion, $dependency->getName())) {
+                    return false;
+                }
+            }
+
+            return true;
         });
     }
 }

--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -97,7 +97,6 @@ final class UnusedCommand extends BaseCommand
             new CollectConsumedSymbolsCommand(
                 $baseDir,
                 $rootPackage
-                // TODO add excludes
             )
         );
 
@@ -112,7 +111,8 @@ final class UnusedCommand extends BaseCommand
         $requiredDependencyCollection = $this->collectFilteredDependenciesCommandHandler->collect(
             new FilterDependencyCollectionCommand(
                 $unfilteredRequiredDependencyCollection,
-                $input->getOption('excludePackage')
+                $input->getOption('excludePackage'),
+                [] // TODO use pattern exclude option from command line
             )
         );
 

--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -138,4 +138,21 @@ class UnusedCommandTest extends TestCase
 
         self::assertStringNotContainsString('dummy/test-package', $output->fetch());
     }
+
+    /**
+     * @test
+     */
+    public function itShouldNotReportPatternExcludedPackages(): void
+    {
+        chdir(__DIR__ . '/../assets/TestProjects/IgnorePatternPackages');
+
+        $output = new BufferedOutput();
+
+        $this->getApplication()->run(
+            new ArrayInput(['unused']),
+            $output
+        );
+
+        self::assertStringNotContainsString('-implementation', $output->fetch());
+    }
 }

--- a/tests/assets/TestProjects/IgnorePatternPackages/composer.json
+++ b/tests/assets/TestProjects/IgnorePatternPackages/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "ns/lib",
+    "require": {
+        "dummy/test-package": "1.0",
+        "psr/log-implementation": "1.0.0",
+        "dummy/ff-implementation": "1.0.0"
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Additional information
This PR adds support for regex pattern exclusions. By default it excludes "-implementation" and therefore fixes issue #93.

### Notes
Should I add all virtual packages to named exclusions? Can they easily be found? 