### PR TITLE
Specify Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You can also install `composer-unused` as a local __development__ dependency:
 ## Usage
 Depending on the kind of your installation the command might differ.
 
+*Note: Packages must installed via `composer install` or `composer update` prior to running `composer-unused`.*
+
 ### PHAR
 The `phar` archive can be run directly in you project:
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

### Docs

Added a note to specify that packages must be installer prior to running `composer-unused`. While this might seem apparent it is not necessarily the case under CI/CD. Probably a better solution in the future would be to throw an error if no Composer autoload can be found.