### PR TITLE
Resolve #281: Change filter usage state only once

### DIFF
--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -281,7 +281,7 @@ final class UnusedCommand extends Command
         }
 
         $io->newLine();
-        $io->text('<fg=magenta>Zombies exclusions</> (<fg=cyan>did not match any package)</>)');
+        $io->text('<fg=magenta>Zombies exclusions</> (<fg=cyan>did not match any package</>)');
 
         foreach ($filterCollection->getUnused() as $filter) {
             $io->writeln(

--- a/src/Filter/NamedFilter.php
+++ b/src/Filter/NamedFilter.php
@@ -20,7 +20,13 @@ final class NamedFilter implements FilterInterface
 
     public function applies(DependencyInterface $dependency): bool
     {
-        return $this->used = $dependency->getName() === $this->filterString;
+        $applies = $dependency->getName() === $this->filterString;
+
+        if ($this->used === false && $applies === true) {
+            $this->used = true;
+        }
+
+        return $applies;
     }
 
     public function used(): bool

--- a/tests/Unit/Filter/NamedFilterTest.php
+++ b/tests/Unit/Filter/NamedFilterTest.php
@@ -42,4 +42,18 @@ final class NamedFilterTest extends TestCase
         self::assertFalse($filter->applies($dependency), 'dependency named "fubar" should not apply to named filter "test"');
         self::assertFalse($filter->used());
     }
+
+    /**
+     * @test
+     */
+    public function itShouldRemainUsed(): void
+    {
+        $filter = new NamedFilter('test');
+        $dependencyA = new TestDependency('test');
+        $dependencyB = new TestDependency('fubar');
+
+        self::assertTrue($filter->applies($dependencyA), 'dependency named "test" should apply to named filter "test"');
+        self::assertFalse($filter->applies($dependencyB), 'dependency named "fubar" should not apply to named filter "test"');
+        self::assertTrue($filter->used(), 'Filter should remain used');
+    }
 }


### PR DESCRIPTION
Filter usage state should only change when it applies and it wasn't used before
