### PR TITLE
Allow list of paths for a single namespace specification

### DIFF
--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -155,4 +155,17 @@ class UnusedCommandTest extends TestCase
         self::assertStringNotContainsString('dummy/test-package', $commandTester->getDisplay());
         self::assertStringContainsString('Found 3 used, 0 unused, 0 ignored and 0 zombie packages', $commandTester->getDisplay());
     }
+
+    /**
+     * @test
+     */
+    public function itShouldHaveZeroExitCodeOnArrayNamespace(): void
+    {
+        chdir(__DIR__ . '/../assets/TestProjects/ArrayNamespace');
+        $commandTester = new CommandTester($this->container->get(UnusedCommand::class));
+
+        $exitCode = $commandTester->execute([]);
+
+        self::assertSame(0, $exitCode);
+    }
 }

--- a/tests/assets/TestProjects/ArrayNamespace/composer.json
+++ b/tests/assets/TestProjects/ArrayNamespace/composer.json
@@ -1,0 +1,10 @@
+{
+  "name": "foo/bar",
+  "require": {
+  },
+  "autoload": {
+    "psr-4": {
+      "EmptyRequire\\": ["src/"]
+    }
+  }
+}

--- a/tests/assets/TestProjects/ArrayNamespace/src/TestClass.php
+++ b/tests/assets/TestProjects/ArrayNamespace/src/TestClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EmptyRequire;
+
+class TestClass
+{
+    public function testMethod(): void
+    {
+    }
+}


### PR DESCRIPTION
This PR will allow multiple paths to be specified per namespace.

The first commit replicates the issue I encountered and reported in https://github.com/composer-unused/composer-unused/issues/293

Note: I just realised the root of this particular issue is outside the package. I'll try to resolve it in the `composer-unused/symbol-parser` package in the next days.

Signed-off-by: Agustin Gomes <me@agustingomes.com>

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

