### PR TITLE
[PHP 8.1]  Uncaught Error: Typed property ComposerUnused\ComposerUnused\Composer\Config::$name must not be accessed before initialization

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -8,7 +8,7 @@ final class Config
 {
     /** @var array<string, mixed> */
     protected array $config = [];
-    protected string $name;
+    protected string $name = '';
     /** @var array<string, mixed> */
     private array $require = [];
     /** @var array<string, mixed> */


### PR DESCRIPTION
Add support for PHP 8.1.2

Without this PR it fails:

```
PHP Fatal error:  Uncaught Error: Typed property ComposerUnused\ComposerUnused\Composer\Config::$name must not be accessed before initialization in /Users/kalachev/Sites/api/vendor/icanhazstring/composer-unused/src/Composer/Config.php:23
Stack trace:
#0 /Users/kalachev/Sites/api/vendor/icanhazstring/composer-unused/src/Composer/Package.php(22): ComposerUnused\ComposerUnused\Composer\Config->getName()
#1 /Users/kalachev/Sites/api/vendor/icanhazstring/composer-unused/src/Console/Command/UnusedCommand.php(127): ComposerUnused\ComposerUnused\Composer\Package::fromConfig(Object(ComposerUnused\ComposerUnused\Composer\Config))
#2 /Users/kalachev/Sites/api/vendor/symfony/console/Command/Command.php(291): ComposerUnused\ComposerUnused\Console\Command\UnusedCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /Users/kalachev/Sites/api/vendor/symfony/console/Application.php(989): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /Users/kalachev/Sites/api/vendor/symfony/console/Application.php(299): Symfony\Component\Console\Application->doRunCommand(Object(ComposerUnused\ComposerUnused\Console\Command\UnusedCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /Users/kalachev/Sites/api/vendor/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /Users/kalachev/Sites/api/vendor/icanhazstring/composer-unused/bin/composer-unused(45): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput))
#7 /Users/kalachev/Sites/api/vendor/icanhazstring/composer-unused/bin/composer-unused(46): {closure}(Array)
#8 /Users/kalachev/Sites/api/vendor/bin/composer-unused(117): include('/Users/kalachev...')
#9 {main}
  thrown in /Users/kalachev/Sites/api/vendor/icanhazstring/composer-unused/src/Composer/Config.php on line 23
```

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
