### PR TITLE
Avoid strpos comparison for php package

### DIFF
--- a/src/PackageResolver.php
+++ b/src/PackageResolver.php
@@ -15,7 +15,7 @@ final class PackageResolver
         LinkInterface $packageLink,
         RepositoryInterface $repository
     ): ?PackageInterface {
-        $isPhp = strpos($packageLink->getTarget(), 'php') === 0;
+        $isPhp = $packageLink->getTarget() === 'php';
         $isExtension = strpos($packageLink->getTarget(), 'ext-') === 0;
 
         if ($isPhp || $isExtension) {


### PR DESCRIPTION
We need to avoid strpos to allow packages containing `php` in their package name at the beginning to be found and parsed correctly

Resolve #316 #317
