### PR TITLE
Make Required Dependencies faster

### DIFF
--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -31,7 +31,7 @@ final class Package implements PackageInterface
         $this->requires = \array_combine(
             \array_map(static fn(LinkInterface $link): string => $link->getTarget(), $requires),
             $requires
-        );
+        ) ?: [];
     }
 
     public function getAutoload(): array

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -11,7 +11,7 @@ use ComposerUnused\Contracts\PackageInterface;
 final class Package implements PackageInterface
 {
     private string $name;
-    /** @var array<LinkInterface> */
+    /** @var array<string, LinkInterface> */
     private array $requires = [];
     /** @var array<string> */
     private array $suggests = [];
@@ -27,8 +27,11 @@ final class Package implements PackageInterface
     {
         $this->name = $name;
         $this->autoload = $autoload;
-        $this->requires = $requires;
         $this->suggests = $suggests;
+        $this->requires = \array_combine(
+            \array_map(static fn(LinkInterface $link): string => $link->getTarget(), $requires),
+            $requires
+        );
     }
 
     public function getAutoload(): array
@@ -43,20 +46,12 @@ final class Package implements PackageInterface
 
     public function getRequires(): array
     {
-        return $this->requires;
+        return array_values($this->requires);
     }
 
     public function getSuggests(): array
     {
         return $this->suggests;
-    }
-
-    /**
-     * @param array<LinkInterface> $requires
-     */
-    public function setRequires(array $requires): void
-    {
-        $this->requires = $requires;
     }
 
     /**
@@ -69,10 +64,8 @@ final class Package implements PackageInterface
 
     public function getRequire(string $name): LinkInterface
     {
-        foreach ($this->requires as $require) {
-            if ($require->getTarget() === $name) {
-                return $require;
-            }
+        if (isset($this->requires[$name])) {
+            return $this->requires[$name];
         }
 
         throw LinkNotFoundException::fromMissingLink($name);

--- a/src/Dependency/RequiredDependency.php
+++ b/src/Dependency/RequiredDependency.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace ComposerUnused\ComposerUnused\Dependency;
 
+use ComposerUnused\Contracts\Exception\LinkNotFoundException;
 use ComposerUnused\Contracts\PackageInterface;
 use ComposerUnused\SymbolParser\Symbol\SymbolInterface;
 use ComposerUnused\SymbolParser\Symbol\SymbolList;
 use ComposerUnused\SymbolParser\Symbol\SymbolListInterface;
-
-use function array_key_exists;
 
 final class RequiredDependency implements DependencyInterface
 {
@@ -62,13 +61,12 @@ final class RequiredDependency implements DependencyInterface
 
     public function requires(DependencyInterface $dependency): bool
     {
-        foreach ($this->package->getRequires() as $require) {
-            if ($require->getTarget() === $dependency->getName()) {
-                return true;
-            }
+        try {
+            $this->package->getRequire($dependency->getName());
+            return true;
+        } catch (LinkNotFoundException $exception) {
+            return false;
         }
-
-        return false;
     }
 
     public function suggests(DependencyInterface $dependency): bool

--- a/tests/Unit/Dependency/RequiredDependencyTest.php
+++ b/tests/Unit/Dependency/RequiredDependencyTest.php
@@ -51,10 +51,11 @@ class RequiredDependencyTest extends TestCase
             new SymbolList()
         );
 
-        $requiredPackage = new Package('required/pacakge');
-        $requiredPackage->setRequires([
-            'root/requirement' => new Link('root/requirement', 0)
-        ]);
+        $requiredPackage = new Package(
+            'required/pacakge',
+            [],
+            [new Link('root/requirement', 0)]
+        );
 
         $requiredDependency = new RequiredDependency($requiredPackage, new SymbolList());
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Related to: https://github.com/composer-unused/composer-unused/issues/321

Hello!
My first PR here. 

Small improvement for the execution time. When checking one of the project I've made [profile ](https://blackfire.io/profiles/ffd6dc8a-9aa3-42bb-bdc9-308f947ef930/graph) - execution took 5 min 14s. It looks like iterating over the required packages is really slow - but it could be easily updated - we can improve internal logic of `Package` class to store it under associative array that reduces complexity for access time. Where is a result of this PoC - [profile](https://blackfire.io/profiles/ffd6dc8a-9aa3-42bb-bdc9-308f947ef930/graph) - execution time reduced to  3mins 49s. 

As a next step I would propose to add `public function requires(string $name): bool` method to `PackageInterface` - it will reduce execution time to 2 min 36 s [profile](https://blackfire.io/profiles/90d0ebdd-31ed-41f6-9050-abf67d3528b6/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()&constraintDoc=)  - so in result it will be twice faster with low effort ;)
 