### PR TITLE
Split independent loops during looking for used packages

### DIFF
--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -189,24 +189,31 @@ final class UnusedCommand extends Command
                     $requiredDependency->markUsed();
                     continue;
                 }
+            }
+        }
 
-                /** @var RequiredDependency $secondRequiredDependency */
-                foreach ($requiredDependencyCollection as $secondRequiredDependency) {
-                    if ($requiredDependency === $secondRequiredDependency) {
-                        continue;
-                    }
+        foreach ($requiredDependencyCollection as $requiredDependency) {
+            if (
+                $requiredDependency->inState($requiredDependency::STATE_USED)
+            ) {
+                continue;
+            }
+            /** @var RequiredDependency $secondRequiredDependency */
+            foreach ($requiredDependencyCollection as $secondRequiredDependency) {
+                if ($requiredDependency === $secondRequiredDependency) {
+                    continue;
+                }
 
-                    if ($secondRequiredDependency->requires($requiredDependency)) {
-                        $requiredDependency->requiredBy($secondRequiredDependency);
-                        $requiredDependency->markUsed();
-                        continue 2;
-                    }
+                if ($secondRequiredDependency->requires($requiredDependency)) {
+                    $requiredDependency->requiredBy($secondRequiredDependency);
+                    $requiredDependency->markUsed();
+                    continue 2;
+                }
 
-                    if ($secondRequiredDependency->suggests($requiredDependency)) {
-                        $requiredDependency->suggestedBy($secondRequiredDependency);
-                        $requiredDependency->markUsed();
-                        continue 2;
-                    }
+                if ($secondRequiredDependency->suggests($requiredDependency)) {
+                    $requiredDependency->suggestedBy($secondRequiredDependency);
+                    $requiredDependency->markUsed();
+                    continue 2;
                 }
             }
         }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Related to: https://github.com/composer-unused/composer-unused/issues/321

After previous PR I was trying to understanding what is happening inside the loops that is causing many calls to checking relations between packages. It looks like for each file we were trying to find packages that are suggested or required by others. 

As the loop is independent on the main loop over files we can run it once before iterating over files - with the same results. 

[Baseline: 4 min 56 s ](https://blackfire.io/profiles/75280e88-ef4d-4c85-843a-52e777f15a83/graph)
[After changes: 1 min 06 s ](https://blackfire.io/profiles/00203bfc-3327-4882-a4c1-687193061a77/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()&constraintDoc=)

[Comparison: - 3 min 50 s (-78%)](https://blackfire.io/profiles/compare/75280e88-ef4d-4c85-843a-52e777f15a83...00203bfc-3327-4882-a4c1-687193061a77/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()&constraintDoc=) 
  