### PR TITLE
Keep the PatternFilter in used state

### DIFF
--- a/composer-unused.php
+++ b/composer-unused.php
@@ -9,7 +9,7 @@ use Webmozart\Glob\Glob;
 return static function (Configuration $config): Configuration {
     return $config
         // ->addNamedFilter(NamedFilter::fromString('symfony/config'))
-        // ->addPatternFilter(PatternFilter::fromString('/symfony-.*/'))
+        // ->addPatternFilter(PatternFilter::fromString('/symfony\/.*/'))
         ->setAdditionalFilesFor('icanhazstring/composer-unused', [
             __FILE__,
             ...Glob::glob(__DIR__ . '/config/*.php'),

--- a/src/Filter/PatternFilter.php
+++ b/src/Filter/PatternFilter.php
@@ -26,7 +26,11 @@ final class PatternFilter implements FilterInterface
 
     public function applies(DependencyInterface $dependency): bool
     {
-        return $this->used = (bool)preg_match($this->pattern->toString(), $dependency->getName());
+        $applies = preg_match($this->pattern->toString(), $dependency->getName()) > 0;
+
+        $this->used = $this->used || $applies;
+
+        return $applies;
     }
 
     public function used(): bool

--- a/src/Filter/PatternFilter.php
+++ b/src/Filter/PatternFilter.php
@@ -28,7 +28,9 @@ final class PatternFilter implements FilterInterface
     {
         $applies = preg_match($this->pattern->toString(), $dependency->getName()) > 0;
 
-        $this->used = $this->used || $applies;
+        if ($this->used === false && $applies === true) {
+            $this->used = true;
+        }
 
         return $applies;
     }

--- a/tests/Unit/Filter/PatternFilterTest.php
+++ b/tests/Unit/Filter/PatternFilterTest.php
@@ -45,4 +45,23 @@ final class PatternFilterTest extends TestCase
         self::assertFalse($filter->applies($dependency), 'dependency named "fubar" should not apply to pattern "/test/"');
         self::assertFalse($filter->used());
     }
+
+    /**
+     * @test
+     */
+    public function itShouldRemainUsed(): void
+    {
+        $filter = PatternFilter::fromString('/test/');
+        $dependencyApplies = new TestDependency('test');
+        $dependencyNotApplies = new TestDependency('fubar');
+
+        self::assertFalse($filter->applies($dependencyNotApplies), 'dependency named "fubar" should not apply to pattern "/test/"');
+        self::assertFalse($filter->used());
+
+        self::assertTrue($filter->applies($dependencyApplies), 'dependency named "test" should apply to pattern "/test/"');
+        self::assertTrue($filter->used());
+
+        self::assertFalse($filter->applies($dependencyNotApplies), 'dependency named "fubar" should not apply to pattern "/test/"');
+        self::assertTrue($filter->used());
+    }
 }


### PR DESCRIPTION
Hey,

I noticed a small bug.
The PatternFilter does not keep the used state when a following dependency does not match.
So the filter is listed as zombie and the script ends with the error code 1.

And another little thing I noticed and I don't know if it was intentional, but the example pattern in composer-unused.php doesn't cover all Symfony components.

Greetings.