### PR TITLE
Wire up custom configuration file location support

### DIFF
--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -109,9 +109,9 @@ final class UnusedCommand extends Command
         $this->addOption(
             'configuration',
             'c',
-            InputOption::VALUE_REQUIRED,
+            InputOption::VALUE_OPTIONAL,
             'composer-unused configuration file',
-            getcwd() . DIRECTORY_SEPARATOR . 'composer-unused.php'
+            null
         );
     }
 
@@ -136,7 +136,7 @@ final class UnusedCommand extends Command
         $rootPackage = $this->packageFactory->fromConfig($composerConfig);
         $localRepository = $this->localRepositoryFactory->create($composerConfig);
         $baseDir = dirname($composerJsonPath);
-        $configuration = $this->loadConfiguration($baseDir);
+        $configuration = $this->loadConfiguration($input->getOption('configuration') ?: $baseDir . DIRECTORY_SEPARATOR . 'composer-unused.php');
 
         $consumedSymbols = $this->collectConsumedSymbolsCommandHandler->collect(
             new CollectConsumedSymbolsCommand(
@@ -251,9 +251,8 @@ final class UnusedCommand extends Command
         );
     }
 
-    private function loadConfiguration(string $baseDir): Configuration
+    private function loadConfiguration(string $configPath): Configuration
     {
-        $configPath = $baseDir . DIRECTORY_SEPARATOR . 'composer-unused.php';
         $configuration = new Configuration();
 
         if (!file_exists($configPath)) {

--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -145,7 +145,25 @@ class UnusedCommandTest extends TestCase
     public function itShouldNotReportDependencyWithAdditionalFile(): void
     {
         $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));
-        $exitCode = $commandTester->execute(['composer-json' => __DIR__ . '/../assets/TestProjects/DependencyWithAdditionalFile/composer.json']);
+        $exitCode = $commandTester->execute(['composer-json' => __DIR__ . '/../assets/TestProjects/DependencyWithAdditionalFile/composer.json',]);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString(
+            'Found 1 used, 0 unused, 0 ignored and 0 zombie packages',
+            $commandTester->getDisplay()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotReportDependencyWithAdditionalFileWithComposerUnusedInEtc(): void
+    {
+        $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));
+        $exitCode = $commandTester->execute([
+            'composer-json' => __DIR__ . '/../assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/composer.json',
+            '--configuration' => __DIR__ . '/../assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/etc/composer-unused.php',
+        ]);
 
         self::assertSame(0, $exitCode);
         self::assertStringContainsString(

--- a/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/composer.json
+++ b/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "foo/bar",
+  "require": {
+      "test/file-dependency": "*"
+  },
+  "autoload": {
+    "psr-4": {
+      "FileDependencyFunctionWithGuard\\": "src/"
+    }
+  }
+}

--- a/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/etc/composer-unused.php
+++ b/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/etc/composer-unused.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+
+return static function (Configuration $config): Configuration {
+    return $config
+        ->setAdditionalFilesFor('test/file-dependency', [
+            __DIR__ . '/../vendor/test/file-dependency/src/file.php'
+        ]);
+};

--- a/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/src/TestClass.php
+++ b/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/src/TestClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DependencyWithAdditionalFile;
+
+class TestClass
+{
+    public function testMethod(): void
+    {
+        $b = testfunction13();
+    }
+}

--- a/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/vendor/composer/installed.php
+++ b/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/vendor/composer/installed.php
@@ -1,0 +1,17 @@
+<?php return array(
+    'root' => array(
+        'pretty_version' => '1.0.0+no-version-set',
+        'version' => '1.0.0.0',
+        'type' => 'library',
+        'install_path' => __DIR__ . '/../../',
+        'aliases' => array(),
+        'reference' => NULL,
+        'name' => 'foo/bar',
+        'dev' => true,
+    ),
+    'versions' => array(
+        'test/file-dependency' => array(
+            'install_path' => __DIR__ . '/../test/file-dependency',
+        ),
+    ),
+);

--- a/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/vendor/test/file-dependency/composer.json
+++ b/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/vendor/test/file-dependency/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "test/file-dependency",
+    "type": "library",
+    "description": "test dependency",
+    "autoload": {
+        "psr-4": {
+            "FileDependency\\": "src"
+        }
+    },
+    "require": {
+    },
+    "require-dev": {
+    }
+}

--- a/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/vendor/test/file-dependency/src/file.php
+++ b/tests/assets/TestProjects/DependencyWithAdditionalFileWithComposerUnusedInEtc/vendor/test/file-dependency/src/file.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('testfunction13')) {
+    function testfunction13() {}
+}


### PR DESCRIPTION
The configuration option is there but never wired up to be used

Refs: https://github.com/WyriHaximus/php-test-utilities/pull/603

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
