### PR TITLE
Mark new "composer" platform requirement as globally excluded. (Fixes: #381)

### DIFF
--- a/src/Filter/FilterCollection.php
+++ b/src/Filter/FilterCollection.php
@@ -20,6 +20,7 @@ final class FilterCollection implements IteratorAggregate, Countable
      * Value => always "used"
      */
     private const GLOBAL_NAMED_EXCLUSION = [
+        'composer' => true,
         'composer-plugin-api' => true,
         'composer-runtime-api' => true,
         'composer-unused/composer-unused-plugin' => true


### PR DESCRIPTION
Fixes: https://github.com/composer-unused/composer-unused/issues/381