### PR TITLE
Lexer version detector patch

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -78,7 +78,7 @@ return static function (ContainerConfigurator $configurator) {
 
     if (PHP_VERSION_ID < 80000) {
         $lexerVersion = Emulative::PHP_7_4;
-    } elseif (PHP_VERSION_ID < 81000) {
+    } elseif (PHP_VERSION_ID < 80100) {
         $lexerVersion = Emulative::PHP_8_0;
     }
 


### PR DESCRIPTION
For PHP version 8.1.3 the `PHP_VERSION_ID` is `80103`.

This fixes the issue reported in https://github.com/composer-unused/composer-unused/issues/326.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
