### PR TITLE
override exit code with "0" if option `--ignore-exit-code` is used

### DIFF
--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -120,6 +120,7 @@ final class UnusedCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $outputFormatter = $this->formatterFactory->create($input->getOption('output-format'));
         $composerJsonPath = $input->getArgument('composer-json');
+        $ignoreExitCode = (bool)$input->getOption('ignore-exit-code');
 
         if (!file_exists($composerJsonPath) || !is_readable($composerJsonPath)) {
             $io->error(
@@ -129,7 +130,7 @@ final class UnusedCommand extends Command
                 )
             );
 
-            return 1;
+            return $ignoreExitCode ? 0 : 1;
         }
 
         $composerConfig = $this->configFactory->fromPath($composerJsonPath);
@@ -240,7 +241,7 @@ final class UnusedCommand extends Command
             ) => $dependency->inState($dependency::STATE_IGNORED) || $dependency->inState($dependency::STATE_INVALID)
         );
 
-        return $outputFormatter->formatOutput(
+        $exitCode = $outputFormatter->formatOutput(
             $rootPackage,
             $composerJsonPath,
             $usedDependencyCollection,
@@ -249,6 +250,8 @@ final class UnusedCommand extends Command
             $filterCollection,
             $io
         );
+
+        return !$ignoreExitCode ? $exitCode : 0;
     }
 
     private function loadConfiguration(string $configPath): Configuration

--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -222,6 +222,30 @@ class UnusedCommandTest extends TestCase
     /**
      * @test
      */
+    public function itShouldHaveZeroExitCodeWithIgnoreExitCodeOptionOnError(): void
+    {
+        $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));
+
+        $exitCode = $commandTester->execute(['--ignore-exit-code' => null, 'composer-json' => __DIR__ . '/not-existing-composer.json']);
+
+        self::assertSame(0, $exitCode);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldHaveExitCodeUnequalToZeroOnError(): void
+    {
+        $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));
+
+        $exitCode = $commandTester->execute(['composer-json' => __DIR__ . '/not-existing-composer.json']);
+
+        self::assertNotEquals(0, $exitCode);
+    }
+
+    /**
+     * @test
+     */
     public function itShouldHaveZeroExitCodeOnArrayNamespace(): void
     {
         chdir(__DIR__ . '/../assets/TestProjects/ArrayNamespace');


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

This handles the issue #378