### PR TITLE
Add testcase for readonly class (#369)

### DIFF
--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -222,6 +222,21 @@ class UnusedCommandTest extends TestCase
     /**
      * @test
      */
+    public function itShouldRunWithReadonlyClassInDependency(): void
+    {
+        $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));
+        $exitCode = $commandTester->execute(['composer-json' => __DIR__ . '/../assets/TestProjects/DependencyWithReadonlyClass/composer.json']);
+
+        self::assertStringContainsString(
+            'Found 1 used, 0 unused, 0 ignored and 0 zombie packages',
+            $commandTester->getDisplay()
+        );
+        self::assertSame(0, $exitCode);
+    }
+
+    /**
+     * @test
+     */
     public function itShouldHaveZeroExitCodeWithIgnoreExitCodeOptionOnError(): void
     {
         $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));

--- a/tests/assets/TestProjects/DependencyWithReadonlyClass/composer.json
+++ b/tests/assets/TestProjects/DependencyWithReadonlyClass/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "foo/bar",
+  "require": {
+      "test/file-dependency": "*"
+  },
+  "autoload": {
+    "psr-4": {
+      "DependencyWithReadonlyClass\\": "./src/"
+    }
+  }
+}

--- a/tests/assets/TestProjects/DependencyWithReadonlyClass/src/TestClass.php
+++ b/tests/assets/TestProjects/DependencyWithReadonlyClass/src/TestClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DependencyWithReadonlyClass;
+
+use FileDependency\DependencyClass;
+
+class TestClass
+{
+    public function testMethod(): void
+    {
+        $a = new DependencyClass();
+    }
+}

--- a/tests/assets/TestProjects/DependencyWithReadonlyClass/vendor/composer/installed.php
+++ b/tests/assets/TestProjects/DependencyWithReadonlyClass/vendor/composer/installed.php
@@ -1,0 +1,17 @@
+<?php return array(
+    'root' => array(
+        'pretty_version' => '1.0.0+no-version-set',
+        'version' => '1.0.0.0',
+        'type' => 'library',
+        'install_path' => __DIR__ . '/../../',
+        'aliases' => array(),
+        'reference' => NULL,
+        'name' => 'foo/bar',
+        'dev' => true,
+    ),
+    'versions' => array(
+        'test/file-dependency' => array(
+            'install_path' => __DIR__ . '/../test/file-dependency',
+        ),
+    ),
+);

--- a/tests/assets/TestProjects/DependencyWithReadonlyClass/vendor/test/file-dependency/composer.json
+++ b/tests/assets/TestProjects/DependencyWithReadonlyClass/vendor/test/file-dependency/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "test/file-dependency",
+    "type": "library",
+    "description": "test dependency",
+    "autoload": {
+        "psr-4": {
+            "FileDependency\\": "src"
+        }
+    },
+    "require": {
+    },
+    "require-dev": {
+    }
+}

--- a/tests/assets/TestProjects/DependencyWithReadonlyClass/vendor/test/file-dependency/src/DependencyClass.php
+++ b/tests/assets/TestProjects/DependencyWithReadonlyClass/vendor/test/file-dependency/src/DependencyClass.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FileDependency;
+
+class DependencyClass {}

--- a/tests/assets/TestProjects/DependencyWithReadonlyClass/vendor/test/file-dependency/src/DependencyClass.php
+++ b/tests/assets/TestProjects/DependencyWithReadonlyClass/vendor/test/file-dependency/src/DependencyClass.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 namespace FileDependency;
 
-class DependencyClass {}
+readonly class DependencyClass {}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

This PR adds a testcase for a readonly dependency as suggested in issue #369.