### PR TITLE
Fix #342 - Empty PSR4 namespace

### DIFF
--- a/src/Command/Handler/CollectConsumedSymbolsCommandHandler.php
+++ b/src/Command/Handler/CollectConsumedSymbolsCommandHandler.php
@@ -33,9 +33,11 @@ final class CollectConsumedSymbolsCommandHandler
             ->setAdditionalFiles($command->getConfiguration()->getAdditionalFilesFor($package->getName()))
             ->build();
 
-        $rootNamespaces = array_merge(
-            array_keys($package->getAutoload()['psr-0'] ?? []),
-            array_keys($package->getAutoload()['psr-4'] ?? [])
+        $rootNamespaces = array_filter( // Remove empty PSR-4 namespaces (see issue 342)*/
+            array_merge(
+                array_keys($package->getAutoload()['psr-0'] ?? []),
+                array_keys($package->getAutoload()['psr-4'] ?? [])
+            )
         );
 
         yield from $this->filterRootPackageSymbols(

--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -162,7 +162,7 @@ final class UnusedCommand extends Command
                 'Consider migrating to composer-unused.php configuration.'
             );
         }
-        if (isset($rootPackage->getAutoload()['psr-4'][''])) {
+        if (array_key_exists('', $rootPackage->getAutoload()['psr-4'] ?? [])) {
             $io->warning([
                 'composer.json[autoload][psr-4] contains an empty namespace.',
                 'It\'s usually a bad idea for performance, see output of "composer validate" command.'

--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -162,6 +162,12 @@ final class UnusedCommand extends Command
                 'Consider migrating to composer-unused.php configuration.'
             );
         }
+        if (isset($rootPackage->getAutoload()['psr-4'][''])) {
+            $io->warning([
+                'composer.json[autoload][psr-4] contains an empty namespace.',
+                'It\'s usually a bad idea for performance, see output of "composer validate" command.'
+            ]);
+        }
 
         $filterCollection = new FilterCollection(
             array_merge(

--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -237,6 +237,21 @@ class UnusedCommandTest extends TestCase
     /**
      * @test
      */
+    public function itShouldRunWithEmptyPsr4Namespace(): void
+    {
+        $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));
+        $exitCode = $commandTester->execute(['composer-json' => __DIR__ . '/../assets/TestProjects/EmptyPSR4Namespace/composer.json']);
+
+        self::assertStringContainsString(
+            'Found 1 used, 0 unused, 0 ignored and 0 zombie packages',
+            $commandTester->getDisplay()
+        );
+        self::assertSame(0, $exitCode);
+    }
+
+    /**
+     * @test
+     */
     public function itShouldHaveZeroExitCodeWithIgnoreExitCodeOptionOnError(): void
     {
         $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));

--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -246,6 +246,14 @@ class UnusedCommandTest extends TestCase
             'Found 1 used, 0 unused, 0 ignored and 0 zombie packages',
             $commandTester->getDisplay()
         );
+        self::assertStringContainsString(
+            '[WARNING] composer.json[autoload][psr-4] contains an empty namespace.',
+            $commandTester->getDisplay()
+        );
+        self::assertStringContainsString(
+            'It\'s usually a bad idea for performance, see output of "composer validate" command.',
+            $commandTester->getDisplay()
+        );
         self::assertSame(0, $exitCode);
     }
 

--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -239,6 +239,7 @@ class UnusedCommandTest extends TestCase
      */
     public function itShouldRunWithEmptyPsr4Namespace(): void
     {
+        putenv('COLUMNS=100'); // Avoid line breaks when checking warning message below
         $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));
         $exitCode = $commandTester->execute(['composer-json' => __DIR__ . '/../assets/TestProjects/EmptyPSR4Namespace/composer.json']);
 

--- a/tests/assets/TestProjects/EmptyPSR4Namespace/composer.json
+++ b/tests/assets/TestProjects/EmptyPSR4Namespace/composer.json
@@ -1,0 +1,11 @@
+{
+  "name": "foo/bar",
+  "require": {
+      "test/file-dependency": "*"
+  },
+  "autoload": {
+    "psr-4": {
+      "": "src/"
+    }
+  }
+}

--- a/tests/assets/TestProjects/EmptyPSR4Namespace/src/TestClass.php
+++ b/tests/assets/TestProjects/EmptyPSR4Namespace/src/TestClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RootNS;
+
+use FileDependency\testfunction13;
+
+class TestClass
+{
+    public function testMethod(): void
+    {
+        testfunction13();
+    }
+}

--- a/tests/assets/TestProjects/EmptyPSR4Namespace/vendor/composer/installed.php
+++ b/tests/assets/TestProjects/EmptyPSR4Namespace/vendor/composer/installed.php
@@ -1,0 +1,17 @@
+<?php return array(
+    'root' => array(
+        'pretty_version' => '1.0.0+no-version-set',
+        'version' => '1.0.0.0',
+        'type' => 'library',
+        'install_path' => __DIR__ . '/../../',
+        'aliases' => array(),
+        'reference' => NULL,
+        'name' => 'foo/bar',
+        'dev' => true,
+    ),
+    'versions' => array(
+        'test/file-dependency' => array(
+            'install_path' => __DIR__ . '/../test/file-dependency',
+        ),
+    ),
+);

--- a/tests/assets/TestProjects/EmptyPSR4Namespace/vendor/test/file-dependency/composer.json
+++ b/tests/assets/TestProjects/EmptyPSR4Namespace/vendor/test/file-dependency/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "test/file-dependency",
+    "type": "library",
+    "description": "test dependency",
+    "autoload": {
+        "psr-4": {
+            "FileDependency\\": "src"
+        }
+    },
+    "require": {
+    },
+    "require-dev": {
+    }
+}

--- a/tests/assets/TestProjects/EmptyPSR4Namespace/vendor/test/file-dependency/src/file.php
+++ b/tests/assets/TestProjects/EmptyPSR4Namespace/vendor/test/file-dependency/src/file.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('testfunction13')) {
+    function testfunction13() {}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
   - See #342 
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
