### PR TITLE
Issue359 - mark required dependencies as used only when checked has u…

### DIFF
--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -211,7 +211,7 @@ final class UnusedCommand extends Command
                     continue;
                 }
 
-                if ($secondRequiredDependency->requires($requiredDependency)) {
+                if ($secondRequiredDependency->requires($requiredDependency) && $secondRequiredDependency->inState($requiredDependency::STATE_USED)) {
                     $requiredDependency->requiredBy($secondRequiredDependency);
                     $requiredDependency->markUsed();
                     continue 2;

--- a/tests/Integration/UnusedCommandTest.php
+++ b/tests/Integration/UnusedCommandTest.php
@@ -204,6 +204,23 @@ class UnusedCommandTest extends TestCase
         );
     }
 
+
+    /**
+     * @test
+     */
+    public function itShouldRunWithMultiDependenciesRequireByWithClassmap(): void
+    {
+        $commandTester = new CommandTester(self::$container->get(UnusedCommand::class));
+        $exitCode = $commandTester->execute(['composer-json' => __DIR__ . '/../assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/composer.json']);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringNotContainsString('dummy/test-package', $commandTester->getDisplay());
+        self::assertStringContainsString(
+            'Found 0 used, 2 unused, 0 ignored and 0 zombie packages',
+            $commandTester->getDisplay()
+        );
+    }
+
     /**
      * @test
      */

--- a/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/composer.json
+++ b/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "ns/lib",
+    "require": {
+        "first/dependency": "*",
+        "second/dependency": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "MultiDependencyWithClassmap\\": "src"
+        }
+    }
+}

--- a/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/src/TestClass.php
+++ b/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/src/TestClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace assets\TestProjects\MultiDependencyWithClassmap\src;
+
+
+final class TestClass
+{
+    public function test(): void
+    {
+    }
+}

--- a/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/composer/installed.php
+++ b/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/composer/installed.php
@@ -1,0 +1,20 @@
+<?php return array(
+    'root' => array(
+        'pretty_version' => '1.0.0+no-version-set',
+        'version' => '1.0.0.0',
+        'type' => 'library',
+        'install_path' => __DIR__ . '/../../',
+        'aliases' => array(),
+        'reference' => NULL,
+        'name' => 'ns/lib',
+        'dev' => true,
+    ),
+    'versions' => array(
+        'first/dependency' => array(
+            'install_path' => __DIR__ . '/../first/dependency',
+        ),
+        'second/dependency' => array(
+            'install_path' => __DIR__ . '/../second/dependency',
+        ),
+    ),
+);

--- a/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/first/dependency/composer.json
+++ b/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/first/dependency/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "first/dependency",
+    "autoload": {
+        "classmap": ["src/"]
+    }
+}

--- a/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/first/dependency/src/FirstDependency.php
+++ b/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/first/dependency/src/FirstDependency.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace First\Dependency;
+
+class FirstDependency {}

--- a/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/second/dependency/composer.json
+++ b/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/second/dependency/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "second/dependency",
+    "autoload": {
+        "classmap": ["src/"]
+    },
+    "require": {
+        "first/dependency": "*"
+    }
+}

--- a/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/second/dependency/src/SecondDependency.php
+++ b/tests/assets/TestProjects/MultiDependencyRequiredByUnusedWithClassmap/vendor/second/dependency/src/SecondDependency.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Second\Dependency;
+
+class SecondDependency {}


### PR DESCRIPTION
…sed status

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x ] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?