### PR TITLE
Fix: Explicitly require symfony/property-access

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/config": "^4.4 || ^5.4 || ^6.0",
         "symfony/console": "^4.4 || ^5.4 || ^6.0",
         "symfony/dependency-injection": "^4.4.8 || ^5.4 || ^6.0",
+        "symfony/property-access": "^4.4 || ^5.4 || ^6.0",
         "symfony/serializer": "^4.4 || ^5.4 || ^6.0",
         "webmozart/assert": "^1.10",
         "webmozart/glob": "^4.4"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

---

Since symfony/symfony#43534 (released with `symfony/serializer` 6.2.0), Symfony's `ObjectNormalizer` has a hard dependency to the `symfony/property-access` package. As we're using the `ObjectNormalizer`, we must ensure to meet this requirement by explicitly adding the package as requirement in `composer.json`.

Otherwise, the following error occurs when running `composer-unused`:

```
PHP Fatal error:  Uncaught Error: Class "Symfony\Component\PropertyAccess\PropertyAccess" not found in composer-unused/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php:328
Stack trace:
#0 composer-unused/vendor/symfony/serializer/Serializer.php(227): Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer->denormalize(Array, 'ComposerUnused\\...', 'json', Array)
#1 composer-unused/vendor/symfony/serializer/Serializer.php(145): Symfony\Component\Serializer\Serializer->denormalize(Array, 'ComposerUnused\\...', 'json', Array)
#2 composer-unused/src/Composer/ConfigFactory.php(36): Symfony\Component\Serializer\Serializer->deserialize(Array, 'ComposerUnused\\...', 'json')
#3 composer-unused/src/Console/Command/UnusedCommand.php(136): ComposerUnused\ComposerUnused\Composer\ConfigFactory->fromPath('/Users/e.haeuss...')
#4 composer-unused/vendor/symfony/console/Command/Command.php(312): ComposerUnused\ComposerUnused\Console\Command\UnusedCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 composer-unused/vendor/symfony/console/Application.php(1020): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 composer-unused/vendor/symfony/console/Application.php(312): Symfony\Component\Console\Application->doRunCommand(Object(ComposerUnused\ComposerUnused\Console\Command\UnusedCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 composer-unused/vendor/symfony/console/Application.php(168): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 composer-unused/bin/composer-unused(45): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput))
#9 composer-unused/bin/composer-unused(46): {closure}(Array)
#10 {main}
  thrown in composer-unused/vendor/symfony/serializer/Normalizer/AbstractObjectNormalizer.php on line 328
```