### PR TITLE
Add "static analysis" tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "library",
     "description": "Show unused packages by scanning your code",
     "keywords": [
+        "static analysis",
         "composer",
         "unused",
         "php-parser"


### PR DESCRIPTION
This tells composer to install composer-unused to require-dev when running composer require without --dev https://github.com/composer/composer/pull/10960