### PR TITLE
Add debug commands to see consumed and defined symbols

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,3 +10,19 @@ A clear and concise description of what the bug is.
 ## Additional information
 If you encounter environment problems, such as memory limit, provide some information
 about your `php -i`
+
+If you encounter a false-positive unused packages give some debug information:
+
+<details>
+  <summary>composer-unused debug:consumed-symbols</summary>
+  ```
+  <output from command>
+  ```
+</details>
+
+<details>
+  <summary>composer-unused debug:defined-symbols [package]</summary>
+  ```
+  <output from command>
+  ```
+</details>

--- a/bin/composer-unused
+++ b/bin/composer-unused
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+use ComposerUnused\ComposerUnused\Console\Command\DebugConsumedSymbolsCommand;
+use ComposerUnused\ComposerUnused\Console\Command\DebugProvidedSymbolsCommand;
 use ComposerUnused\ComposerUnused\Console\Command\UnusedCommand;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
@@ -39,7 +41,9 @@ use Symfony\Component\Console\Input\ArgvInput;
 
     $application = new Application('composer-unused', UnusedCommand::VERSION);
     $application->add($container->get(UnusedCommand::class));
-    $application->setDefaultCommand('unused', true);
+    $application->add($container->get(DebugConsumedSymbolsCommand::class));
+    $application->add($container->get(DebugProvidedSymbolsCommand::class));
+    $application->setDefaultCommand('unused');
 
     $application->run(new ArgvInput($argv));
 })($argv);

--- a/config/services.php
+++ b/config/services.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationProvider;
+use ComposerUnused\ComposerUnused\Console\Command\DebugConsumedSymbolsCommand;
+use ComposerUnused\ComposerUnused\Console\Command\DebugProvidedSymbolsCommand;
 use ComposerUnused\ComposerUnused\Console\Command\UnusedCommand;
 use ComposerUnused\SymbolParser\Parser\PHP\ConsumedSymbolCollector;
 use ComposerUnused\SymbolParser\Parser\PHP\Strategy\AnnotationStrategy;
@@ -50,8 +53,12 @@ return static function (ContainerConfigurator $configurator) {
         ->load($nameSpacePrefix . 'ComposerUnused\\SymbolParser\\', $vendorDir . '/composer-unused/symbol-parser/src/*');
 
     $services->set(UnusedCommand::class)->public();
+    $services->set(DebugConsumedSymbolsCommand::class)->public();
+    $services->set(DebugProvidedSymbolsCommand::class)->public();
 
     $services->set('logger', NullLogger::class);
+
+    $services->set(ConfigurationProvider::class);
 
     $services->set(UsedExtensionSymbolStrategy::class)->args([
         get_loaded_extensions(),

--- a/src/Command/Handler/CollectRequiredDependenciesCommandHandler.php
+++ b/src/Command/Handler/CollectRequiredDependenciesCommandHandler.php
@@ -8,7 +8,6 @@ use ComposerUnused\ComposerUnused\Composer\InvalidPackage;
 use ComposerUnused\SymbolParser\Symbol\SymbolList;
 use ComposerUnused\ComposerUnused\Command\LoadRequiredDependenciesCommand;
 use ComposerUnused\ComposerUnused\Dependency\DependencyCollection;
-use ComposerUnused\ComposerUnused\Dependency\InvalidDependency;
 use ComposerUnused\ComposerUnused\Dependency\RequiredDependency;
 use ComposerUnused\ComposerUnused\PackageResolver;
 use ComposerUnused\ComposerUnused\Symbol\ProvidedSymbolLoaderBuilder;

--- a/src/Configuration/ConfigurationProvider.php
+++ b/src/Configuration/ConfigurationProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Configuration;
+
+/**
+ * @internal
+ */
+final class ConfigurationProvider
+{
+    public function fromPath(string $configPath): Configuration
+    {
+        $configuration = new Configuration();
+
+        if (!file_exists($configPath)) {
+            return $configuration;
+        }
+
+        /** @var callable $configurationFactory */
+        $configurationFactory = require $configPath;
+        return $configurationFactory($configuration);
+    }
+}

--- a/src/Console/Command/DebugConsumedSymbolsCommand.php
+++ b/src/Console/Command/DebugConsumedSymbolsCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Console\Command;
+
+use ComposerUnused\ComposerUnused\Command\CollectConsumedSymbolsCommand;
+use ComposerUnused\ComposerUnused\Command\Handler\CollectConsumedSymbolsCommandHandler;
+use ComposerUnused\ComposerUnused\Composer\ConfigFactory;
+use ComposerUnused\ComposerUnused\Composer\PackageFactory;
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationProvider;
+use ComposerUnused\SymbolParser\Symbol\SymbolInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class DebugConsumedSymbolsCommand extends Command
+{
+    private CollectConsumedSymbolsCommandHandler $collectConsumedSymbolsCommandHandler;
+    private PackageFactory $packageFactory;
+    private ConfigFactory $configFactory;
+    private ConfigurationProvider $configurationProvider;
+
+    public function __construct(
+        ConfigFactory $configFactory,
+        CollectConsumedSymbolsCommandHandler $collectConsumedSymbolsCommandHandler,
+        PackageFactory $packageFactory,
+        ConfigurationProvider $configurationProvider
+    ) {
+        parent::__construct('debug:consumed-symbols');
+        $this->collectConsumedSymbolsCommandHandler = $collectConsumedSymbolsCommandHandler;
+        $this->packageFactory = $packageFactory;
+        $this->configFactory = $configFactory;
+        $this->configurationProvider = $configurationProvider;
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('List all consumed symbols from the root package.');
+
+        $this->addOption(
+            'configuration',
+            'c',
+            InputOption::VALUE_OPTIONAL,
+            'composer-unused configuration file',
+            null
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $config = $this->configFactory->fromPath(getcwd() . DIRECTORY_SEPARATOR . 'composer.json');
+        $rootPackage = $this->packageFactory->fromConfig($config);
+        $baseDir = dirname(getcwd() . DIRECTORY_SEPARATOR . 'composer.json');
+        $configuration = $this->configurationProvider->fromPath(
+            $input->getOption('configuration') ?: $baseDir . DIRECTORY_SEPARATOR . 'composer-unused.php'
+        );
+
+        $symbols = $this->collectConsumedSymbolsCommandHandler->collect(
+            new CollectConsumedSymbolsCommand(
+                $baseDir,
+                $rootPackage,
+                [],
+                $configuration
+            )
+        );
+
+        $symbolNames = array_map(static function (SymbolInterface $symbol) {
+            return $symbol->getIdentifier();
+        }, iterator_to_array($symbols));
+
+        $symbolNames = array_unique($symbolNames);
+        sort($symbolNames);
+
+        foreach ($symbolNames as $symbolName) {
+            $output->writeln($symbolName);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/Command/DebugProvidedSymbolsCommand.php
+++ b/src/Console/Command/DebugProvidedSymbolsCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Console\Command;
+
+use ComposerUnused\ComposerUnused\Composer\ConfigFactory;
+use ComposerUnused\ComposerUnused\Composer\Link;
+use ComposerUnused\ComposerUnused\Composer\LocalRepositoryFactory;
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationProvider;
+use ComposerUnused\ComposerUnused\PackageResolver;
+use ComposerUnused\ComposerUnused\Symbol\ProvidedSymbolLoaderBuilder;
+use ComposerUnused\SymbolParser\Symbol\SymbolInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class DebugProvidedSymbolsCommand extends Command
+{
+    private ConfigFactory $configFactory;
+    private PackageResolver $packageResolver;
+    private ProvidedSymbolLoaderBuilder $providedSymbolLoaderBuilder;
+    private LocalRepositoryFactory $localRepositoryFactory;
+    private ConfigurationProvider $configurationProvider;
+
+    public function __construct(
+        ConfigFactory $configFactory,
+        PackageResolver $packageResolver,
+        ProvidedSymbolLoaderBuilder $providedSymbolLoaderBuilder,
+        LocalRepositoryFactory $localRepositoryFactory,
+        ConfigurationProvider $configurationProvider
+    ) {
+        parent::__construct('debug:provided-symbols');
+        $this->configFactory = $configFactory;
+        $this->packageResolver = $packageResolver;
+        $this->providedSymbolLoaderBuilder = $providedSymbolLoaderBuilder;
+        $this->localRepositoryFactory = $localRepositoryFactory;
+        $this->configurationProvider = $configurationProvider;
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('List all provided symbols from the given package.');
+        $this->addArgument('package', InputArgument::REQUIRED, 'Compose package to list defined symbols');
+
+        $this->addOption(
+            'configuration',
+            'c',
+            InputOption::VALUE_OPTIONAL,
+            'composer-unused configuration file',
+            null
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $config = $this->configFactory->fromPath(getcwd() . DIRECTORY_SEPARATOR . 'composer.json');
+        $baseDir = dirname(getcwd() . DIRECTORY_SEPARATOR . 'composer.json');
+        $localRepository = $this->localRepositoryFactory->create($config);
+        $package = $input->getArgument('package');
+        $configuration = $this->configurationProvider->fromPath(
+            $input->getOption('configuration') ?: $baseDir . DIRECTORY_SEPARATOR . 'composer-unused.php'
+        );
+
+        $composerPackage = $this->packageResolver->resolve(
+            new Link($package, 0),
+            $localRepository
+        );
+
+        if ($composerPackage === null) {
+            $io->error(
+                sprintf('Package "%s" is not installed.', $package)
+            );
+
+            return Command::FAILURE;
+        }
+
+        $packageBaseDir = $baseDir . DIRECTORY_SEPARATOR . $composerPackage->getName();
+
+        $providedSymbolLoader = $this
+            ->providedSymbolLoaderBuilder
+            ->setAdditionalFiles(($configuration)->getAdditionalFilesFor($composerPackage->getName()))
+            ->build();
+
+        $symbols = $providedSymbolLoader->withBaseDir($packageBaseDir)->load($composerPackage);
+
+        $symbolNames = array_map(static function (SymbolInterface $symbol) {
+            return $symbol->getIdentifier();
+        }, iterator_to_array($symbols));
+
+        foreach ($symbolNames as $symbolName) {
+            $output->writeln($symbolName);
+        }
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
This will add some debug commands to composer-unused.
This should help get more information to debug false-positives.

Should help analyze problems e.g. #462 (#461)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
