### PR TITLE
feat: add gitlab output formatter

### DIFF
--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -79,7 +79,7 @@ final class UnusedCommand extends Command
             'output-format',
             'o',
             InputOption::VALUE_REQUIRED,
-            'Change output style (default, github, json, junit)'
+            'Change output style (default, github, json, junit, gitlab)'
         );
 
         $this->addOption(

--- a/src/OutputFormatter/FormatterFactory.php
+++ b/src/OutputFormatter/FormatterFactory.php
@@ -24,6 +24,8 @@ final class FormatterFactory
                 $ci = $this->ciDetector->detect();
                 if ($ci->getCiName() === CiDetector::CI_GITHUB_ACTIONS) {
                     $type = 'github';
+                } elseif ($ci->getCiName() === CiDetector::CI_GITLAB) {
+                    $type = 'gitlab';
                 }
             } catch (CiNotDetectedException $exception) {
                 $type = 'default';
@@ -37,6 +39,8 @@ final class FormatterFactory
                 return new JsonFormatter();
             case 'junit':
                 return new JUnitFormatter();
+            case 'gitlab':
+                return new GitlabFormatter();
             default:
                 return new DefaultFormatter();
         }

--- a/src/OutputFormatter/GitlabFormatter.php
+++ b/src/OutputFormatter/GitlabFormatter.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\OutputFormatter;
+
+use ComposerUnused\ComposerUnused\Dependency\DependencyCollection;
+use ComposerUnused\ComposerUnused\Filter\FilterCollection;
+use ComposerUnused\Contracts\PackageInterface;
+use Symfony\Component\Console\Style\OutputStyle;
+
+/**
+ * @see https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool
+ */
+final class GitlabFormatter implements OutputFormatterInterface
+{
+    public function formatOutput(
+        PackageInterface $rootPackage,
+        string $composerJsonPath,
+        DependencyCollection $usedDependencyCollection,
+        DependencyCollection $unusedDependencyCollection,
+        DependencyCollection $ignoredDependencyCollection,
+        FilterCollection $filterCollection,
+        OutputStyle $output
+    ): int {
+        $jsonResult = [];
+
+        foreach ($unusedDependencyCollection as $dependency) {
+            $jsonResult[] = [
+                'description' => str_replace("\n", '%0A', sprintf('%s is unused', $dependency->getName())),
+                'fingerprint' => hash('sha256', (sprintf('unused:%s', $dependency->getName()))),
+                'severity' => 'major',
+                'location' => [
+                    'path' => $composerJsonPath,
+                    'lines' => [
+                        'begin' => $rootPackage->getRequire($dependency->getName())->getLineNumber(),
+                    ],
+                ],
+            ];
+        }
+
+        foreach ($ignoredDependencyCollection as $dependency) {
+            $jsonResult[] = [
+                'description' => str_replace("\n", '%0A', sprintf('%s was ignored', $dependency->getName())),
+                'fingerprint' => hash('sha256', (sprintf('ignored:%s', $dependency->getName()))),
+                'severity' => 'info',
+                'location' => [
+                    'path' => $composerJsonPath,
+                    'lines' => [
+                        'begin' => $rootPackage->getRequire($dependency->getName())->getLineNumber(),
+                    ],
+                ],
+            ];
+        }
+
+        foreach ($filterCollection->getUnused() as $filter) {
+            $jsonResult[] = [
+                'description' => str_replace("\n", '%0A', sprintf('%s exclusion is a zombie', $filter->toString())),
+                'fingerprint' => hash('sha256', (sprintf('zombie:%s', $filter->toString()))),
+                'severity' => 'minor',
+                'location' => [
+                    'path' => $composerJsonPath,
+                    'lines' => [
+                        'begin' => 0,
+                    ],
+                ],
+            ];
+        }
+
+        $json = json_encode($jsonResult, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $output->write($json);
+
+        if ($unusedDependencyCollection->count() > 0 || count($filterCollection->getUnused()) > 0) {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/tests/Unit/OutputFormatter/FormatterFactoryTest.php
+++ b/tests/Unit/OutputFormatter/FormatterFactoryTest.php
@@ -7,10 +7,12 @@ namespace ComposerUnused\ComposerUnused\Test\Unit\OutputFormatter;
 use ComposerUnused\ComposerUnused\OutputFormatter\DefaultFormatter;
 use ComposerUnused\ComposerUnused\OutputFormatter\FormatterFactory;
 use ComposerUnused\ComposerUnused\OutputFormatter\GithubFormatter;
+use ComposerUnused\ComposerUnused\OutputFormatter\GitlabFormatter;
 use ComposerUnused\ComposerUnused\OutputFormatter\JsonFormatter;
 use ComposerUnused\ComposerUnused\OutputFormatter\JUnitFormatter;
 use ComposerUnused\ComposerUnused\Test\Stubs\TestDetector;
 use OndraM\CiDetector\Ci\GitHubActions;
+use OndraM\CiDetector\Ci\GitLab;
 use OndraM\CiDetector\CiDetectorInterface;
 use OndraM\CiDetector\Exception\CiNotDetectedException;
 use PHPUnit\Framework\TestCase;
@@ -32,12 +34,23 @@ final class FormatterFactoryTest extends TestCase
     /**
      * @test
      */
-    public function itShouldCreateFormatterByCiDetector(): void
+    public function itShouldCreateGithubFormatterByCiDetector(): void
     {
         $ciDetector = new TestDetector(GitHubActions::class);
 
         $factory = new FormatterFactory($ciDetector);
         self::assertInstanceOf(GithubFormatter::class, $factory->create(null));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldCreateGitlabFormatterByCiDetector(): void
+    {
+        $ciDetector = new TestDetector(GitLab::class);
+
+        $factory = new FormatterFactory($ciDetector);
+        self::assertInstanceOf(GitlabFormatter::class, $factory->create(null));
     }
 
     /**
@@ -50,6 +63,18 @@ final class FormatterFactoryTest extends TestCase
 
         $factory = new FormatterFactory($detector);
         self::assertInstanceOf(GithubFormatter::class, $factory->create('github'));
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldCreateGitlabFormatterOnGitlabType(): void
+    {
+        $detector = $this->createMock(CiDetectorInterface::class);
+        $detector->method('detect')->willThrowException(new CiNotDetectedException());
+
+        $factory = new FormatterFactory($detector);
+        self::assertInstanceOf(GitlabFormatter::class, $factory->create('gitlab'));
     }
 
     /**

--- a/tests/Unit/OutputFormatter/GilabFormatter/Fixture/expected_unused_packages.txt
+++ b/tests/Unit/OutputFormatter/GilabFormatter/Fixture/expected_unused_packages.txt
@@ -1,0 +1,35 @@
+[
+    {
+        "description": "symfony\/console is unused",
+        "fingerprint": "4b53efff62fc3984508b4ed39c1e7bb2c04cc6569633a3d9bc6028407066281a",
+        "severity": "major",
+        "location": {
+            "path": "composer.json",
+            "lines": {
+                "begin": 0
+            }
+        }
+    },
+    {
+        "description": "symfony\/ignored was ignored",
+        "fingerprint": "d490c666cf74cf4c2a4c39f25f59f2dca4ce688deff8b6708168692e2aaf48ae",
+        "severity": "info",
+        "location": {
+            "path": "composer.json",
+            "lines": {
+                "begin": 0
+            }
+        }
+    },
+    {
+        "description": "NamedFilter(userProvided: true, string: symfony\/zombie) exclusion is a zombie",
+        "fingerprint": "3319f0248bbc28a19fba73f1694fc0007835d2e6598bc68ec8eb8810fdbe9ace",
+        "severity": "minor",
+        "location": {
+            "path": "composer.json",
+            "lines": {
+                "begin": 0
+            }
+        }
+    }
+]

--- a/tests/Unit/OutputFormatter/GilabFormatter/GitlabFormatterTest.php
+++ b/tests/Unit/OutputFormatter/GilabFormatter/GitlabFormatterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Test\Unit\OutputFormatter\GilabFormatter;
+
+use ComposerUnused\ComposerUnused\Composer\Package;
+use ComposerUnused\ComposerUnused\Configuration\NamedFilter;
+use ComposerUnused\ComposerUnused\Dependency\DependencyCollection;
+use ComposerUnused\ComposerUnused\Dependency\RequiredDependency;
+use ComposerUnused\ComposerUnused\Filter\FilterCollection;
+use ComposerUnused\ComposerUnused\OutputFormatter\GitlabFormatter;
+use ComposerUnused\Contracts\PackageInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class GitlabFormatterTest extends TestCase
+{
+    private GitlabFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new GitlabFormatter();
+    }
+
+    /**
+     * @test
+     */
+    public function itPrints(): void
+    {
+        $usedCollection = new DependencyCollection([new RequiredDependency(new Package('symfony/string'))]);
+        $unusedCollection = new DependencyCollection([new RequiredDependency(new Package('symfony/console'))]);
+        $ignoredCollection = new DependencyCollection([new RequiredDependency(new Package('symfony/ignored'))]);
+
+        $bufferedOutput = new BufferedOutput();
+        $outputStyle = new SymfonyStyle(new ArgvInput(), $bufferedOutput);
+
+        $this->formatter->formatOutput(
+            $this->createMock(PackageInterface::class),
+            'composer.json',
+            $usedCollection,
+            $unusedCollection,
+            $ignoredCollection,
+            new FilterCollection([NamedFilter::fromString('symfony/zombie')], []),
+            $outputStyle
+        );
+
+        $consoleOutput = $bufferedOutput->fetch() . PHP_EOL;
+        self::assertStringEqualsFile(__DIR__ . '/Fixture/expected_unused_packages.txt', $consoleOutput);
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Description

Hi,

This PR adds a Gitlab output formatter to this project. This can be used with the code quality checks inside a Gitlab Ci envirement.

If you have feedback, I would be happy to hear them!