### PR TITLE
Use stable 8.2 docker image

### DIFF
--- a/.docker/php8.2/Dockerfile
+++ b/.docker/php8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-rc-fpm-alpine
+FROM php:8.2-alpine
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/bin/
 RUN chmod +x /usr/bin/install-php-extensions

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "7.4", "8.0", "8.1" ]
+        php: [ "7.4", "8.0", "8.1", 8.2 ]
         os: [ "ubuntu-latest" ]
         experimental: [ false ]
         include:
@@ -72,9 +72,6 @@ jobs:
             composer-options: "--prefer-lowest"
             os: "ubuntu-latest"
             experimental: false
-          - php: "8.2"
-            os: "ubuntu-latest"
-            experimental: true
 
     steps:
       - name: Checkout
@@ -100,13 +97,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "7.4", "8.0", "8.1" ]
+        php: [ "7.4", "8.0", "8.1", "8.2" ]
         os: [ "ubuntu-latest" ]
         experimental: [ false ]
-        include:
-          - php: "8.2"
-            os: "ubuntu-latest"
-            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?


I saw that the Dockerfile for 8.2 was using the RC image. I changed that up. 
And if I edit the GitHub action file correctly, it should now be required to pass. I haven't done much with GitHub action, so let me know if something is wrong.
