### PR TITLE
Improve user experience when adding additional files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "ext-ds": "*",
         "ext-zend-opcache": "*",
         "bamarni/composer-bin-plugin": "^1.8",
+        "codeception/verify": "^3.0",
         "dg/bypass-finals": "^1.4",
         "ergebnis/composer-normalize": "^2.28",
         "jangregor/phpstan-prophecy": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3b370b4d2ea5c5324877262e187f6e8",
+    "content-hash": "23ecbe4eb986ffa57f4f692c1a8ff006",
     "packages": [
         {
             "name": "composer-unused/contracts",
@@ -2043,6 +2043,55 @@
                 "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.2"
             },
             "time": "2022-10-31T08:38:03+00:00"
+        },
+        {
+            "name": "codeception/verify",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeception/Verify.git",
+                "reference": "25b84a96f0fe7dcf28e8021f02b57643b751a707"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeception/Verify/zipball/25b84a96f0fe7dcf28e8021f02b57643b751a707",
+                "reference": "25b84a96f0fe7dcf28e8021f02b57643b751a707",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^7.4 || ^8.0",
+                "phpunit/phpunit": "^9.5 | ^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Codeception/bootstrap.php"
+                ],
+                "psr-4": {
+                    "Codeception\\": "src\\Codeception"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Bodnarchuk",
+                    "email": "davert@codeception.com"
+                },
+                {
+                    "name": "Gustavo Nieves",
+                    "homepage": "https://medium.com/@ganieves"
+                }
+            ],
+            "description": "BDD assertion library for PHPUnit",
+            "support": {
+                "issues": "https://github.com/Codeception/Verify/issues",
+                "source": "https://github.com/Codeception/Verify/tree/3.0.0"
+            },
+            "time": "2023-02-09T07:33:00+00:00"
         },
         {
             "name": "dg/bypass-finals",

--- a/src/Configuration/AdditionalFilesAlreadySetException.php
+++ b/src/Configuration/AdditionalFilesAlreadySetException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Configuration;
+
+class AdditionalFilesAlreadySetException extends \RuntimeException
+{
+}

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -58,6 +58,12 @@ final class Configuration
      */
     public function setAdditionalFilesFor(string $dependencyName, array $files): self
     {
+        if (array_key_exists($dependencyName, $this->additionalFiles)) {
+            throw new AdditionalFilesAlreadySetException(
+                'You already added files for ' . $dependencyName . '. Did you want to add multiple files? Try adding these via multiple globs.'
+            );
+        }
+
         $this->additionalFiles[$dependencyName] = $files;
         return $this;
     }

--- a/tests/Unit/Configuration/ConfigurationTest.php
+++ b/tests/Unit/Configuration/ConfigurationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Test\Unit\Configuration;
+
+use ComposerUnused\ComposerUnused\Configuration\AdditionalFilesAlreadySetException;
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldSetAdditionalFiles(): void
+    {
+        $config = new Configuration();
+        $config->setAdditionalFilesFor('test/dependency', ['file1.php']);
+
+        $files = $config->getAdditionalFilesFor('test/dependency');
+        expect($files)->notToBeEmpty();
+        expect($files[0])->toBe('file1.php');
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotOverwriteAdditionalFiles(): void
+    {
+        $config = new Configuration();
+        $config->setAdditionalFilesFor('test/dependency', ['file1.php']);
+
+        self::expectException(AdditionalFilesAlreadySetException::class);
+        self::expectExceptionMessage('You already added files for test/dependency. Did you want to add multiple files? Try adding these via multiple globs.');
+        $config->setAdditionalFilesFor('test/dependency', ['file2.php']);
+    }
+}


### PR DESCRIPTION
This will raise an exception when Configuration::setAdditionalFileFor is called multiple times. This should give the user a hint on how to add multiple files.

Resolve #513 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
