### PR TITLE
Only pass composer json filename to output formatter

### DIFF
--- a/src/Composer/Config.php
+++ b/src/Composer/Config.php
@@ -23,6 +23,7 @@ final class Config
     private array $extra = [];
     private string $rawContent;
     private string $baseDir;
+    private string $fileName;
     private ?string $url = null;
 
     public function getName(): string
@@ -96,6 +97,16 @@ final class Config
     public function getBaseDir(): string
     {
         return $this->baseDir;
+    }
+
+    public function getFileName(): string
+    {
+        return $this->fileName;
+    }
+
+    public function setFileName(string $fileName): void
+    {
+        $this->fileName = $fileName;
     }
 
     public function setUrl(?string $url): void

--- a/src/Composer/ConfigFactory.php
+++ b/src/Composer/ConfigFactory.php
@@ -42,6 +42,7 @@ final class ConfigFactory
         $config = $this->serializer->deserialize($composerJson, Config::class, 'json');
         $config->setRaw($composerJson);
         $config->setBaseDir(dirname($jsonPath));
+        $config->setFileName(basename($jsonPath));
 
         $this->validate($config);
 

--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -165,7 +165,7 @@ final class UnusedCommand extends Command
             return $ignoreExitCode ? 0 : 1;
         }
 
-        $baseDir = dirname($composerJsonPath);
+        $baseDir = $composerConfig->getBaseDir();
         $configuration = $this->configurationProvider->fromPath(
             $input->getOption('configuration') ?: $baseDir . DIRECTORY_SEPARATOR . 'composer-unused.php'
         );
@@ -284,7 +284,7 @@ final class UnusedCommand extends Command
 
         $exitCode = $outputFormatter->formatOutput(
             $rootPackage,
-            $composerJsonPath,
+            $composerConfig->getFileName(),
             $usedDependencyCollection,
             $unusedDependencyCollection,
             $ignoredDependencyCollection,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

Fixes #623. Only the filename of the parsed `composer.json` is now given to the output parsers. As this file should always be on the root of the project, this should also be correct for the output formatters.