### PR TITLE
Sort results of `debug:provided-symbols` command

### DIFF
--- a/src/Console/Command/DebugProvidedSymbolsCommand.php
+++ b/src/Console/Command/DebugProvidedSymbolsCommand.php
@@ -117,6 +117,9 @@ final class DebugProvidedSymbolsCommand extends Command
             return $symbol->getIdentifier();
         }, iterator_to_array($symbols));
 
+        $symbolNames = array_unique($symbolNames);
+        sort($symbolNames);
+
         foreach ($symbolNames as $symbolName) {
             $output->writeln($symbolName);
         }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Goal

While `debug:consumed-symbols` command results are sorted in ascending order with PHP [sort](https://www.php.net/manual/en/function.sort) function and default SORT_REGULAR option.

`debug:provided-symbols` command did not have the same behavior.

This PR apply the same behavior on both commands.