### PR TITLE
Add support to PHP-Parser v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,10 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
+        "composer-runtime-api": "^2.0",
         "composer-unused/contracts": "^0.3",
         "composer-unused/symbol-parser": "^0.2.2",
-        "nikic/php-parser": "^4.15",
+        "nikic/php-parser": "^4.18 || ^5.0",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.12",
         "psr/container": "^1.0 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdb2fba8a81287d473caf1fc43082aeb",
+    "content-hash": "0d3bb0290992781d07d94a3ba0d466f9",
     "packages": [
         {
             "name": "composer-unused/contracts",
@@ -5956,10 +5956,11 @@
         "roave/security-advisories": 20
     },
     "prefer-stable": false,
-    "prefer-lowest": false,
+    "prefer-lowest": true,
     "platform": {
         "php": "^7.4 || ^8.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "composer-runtime-api": "^2.0"
     },
     "platform-dev": {
         "ext-ds": "*",

--- a/config/services.php
+++ b/config/services.php
@@ -89,13 +89,19 @@ return static function (ContainerConfigurator $configurator) {
         ->set(ConstExprParser::class, ConstExprParser::class)
         ->set(Lexer::class, Lexer::class);
 
-    $lexerVersion = Emulative::PHP_8_1;
+    [$phpParserMajorVersion, ] = explode('.', Composer\InstalledVersions::getVersion('nikic/php-parser'));
 
-    if (PHP_VERSION_ID < 80000) {
-        $lexerVersion = Emulative::PHP_7_4;
-    } elseif (PHP_VERSION_ID < 80100) {
-        $lexerVersion = Emulative::PHP_8_0;
+    if ($phpParserMajorVersion == '5') {
+        $services->set(Emulative::class);
+    } else {
+        $lexerVersion = Emulative::PHP_8_1;
+
+        if (PHP_VERSION_ID < 80000) {
+            $lexerVersion = Emulative::PHP_7_4;
+        } elseif (PHP_VERSION_ID < 80100) {
+            $lexerVersion = Emulative::PHP_8_0;
+        }
+
+        $services->set(Emulative::class)->arg('$options', ['phpVersion' => $lexerVersion]);
     }
-
-    $services->set(Emulative::class)->arg('$options', ['phpVersion' => $lexerVersion]);
 };

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,11 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Property ComposerUnused\\\\ComposerUnused\\\\Symbol\\\\ConsumedSymbolLoaderBuilder\\:\\:\\$lexer is never read, only written\\.$#"
+			count: 1
+			path: src/Symbol/ConsumedSymbolLoaderBuilder.php
+
+		-
+			message: "#^Property ComposerUnused\\\\ComposerUnused\\\\Symbol\\\\ProvidedSymbolLoaderBuilder\\:\\:\\$lexer is never read, only written\\.$#"
+			count: 1
+			path: src/Symbol/ProvidedSymbolLoaderBuilder.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+	- phpstan-baseline.neon
+
 parameters:
     bootstrapFiles:
         - phpunit.bootstrap.php

--- a/src/Symbol/ConsumedSymbolLoaderBuilder.php
+++ b/src/Symbol/ConsumedSymbolLoaderBuilder.php
@@ -35,7 +35,7 @@ final class ConsumedSymbolLoaderBuilder
     public function build(): SymbolLoaderInterface
     {
         $symbolNameParser = new SymbolNameParser(
-            (new ParserFactory())->create(ParserFactory::ONLY_PHP7, $this->lexer),
+            (new ParserFactory())->createForNewestSupportedVersion(),
             new NameResolver(),
             $this->consumedSymbolCollector
         );

--- a/src/Symbol/ProvidedSymbolLoaderBuilder.php
+++ b/src/Symbol/ProvidedSymbolLoaderBuilder.php
@@ -34,7 +34,7 @@ final class ProvidedSymbolLoaderBuilder
     public function build(): SymbolLoaderInterface
     {
         $symbolNameParser = new SymbolNameParser(
-            (new ParserFactory())->create(ParserFactory::ONLY_PHP7, $this->lexer),
+            (new ParserFactory())->createForNewestSupportedVersion(),
             new NameResolver(),
             new DefinedSymbolCollector()
         );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Goal

Make the Core code of this package compatible with [PHP-Parser](https://github.com/nikic/PHP-Parser) v5 and ready for a new version of `composer-unused/symbol-parser` [also compatible v5](https://github.com/composer-unused/symbol-parser/pull/133)
