### PR TITLE
Add --output-file option to directly write formatted result output to…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "dg/bypass-finals": "^1.6",
         "ergebnis/composer-normalize": "^2.42",
         "jangregor/phpstan-prophecy": "^1.0",
+        "mikey179/vfsstream": "^1.6",
         "php-ds/php-ds": "^1.5",
         "phpspec/prophecy-phpunit": "^2.2.0",
         "phpstan/extension-installer": "^1.3",


### PR DESCRIPTION
I tried to add this via Output classes, but this was a pain, since all the OutputFormatters rely on Symfony Console OutputInterface. Now I simply replace the $io SymfonyStyle with a new SymfonyStyle with BufferedOutput, which also removes all ansi codes on the fly.

A test can be added if needed, but I guess I would need to add something like vfsStream to avoid creating files while testing.
Didn't find tests for e.g. --output-format as well, so I don't know if this is necessary? 
Comment would be appreciated.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
