### PR TITLE
Avoid implicitly nullable types for PHP 8.4 compatibility

### DIFF
--- a/src/Dependency/RequiredDependency.php
+++ b/src/Dependency/RequiredDependency.php
@@ -21,7 +21,7 @@ final class RequiredDependency implements DependencyInterface
     private array $suggestBy = [];
     private string $stateReason = '';
 
-    public function __construct(PackageInterface $package, SymbolListInterface $symbols = null)
+    public function __construct(PackageInterface $package, ?SymbolListInterface $symbols = null)
     {
         $this->package = $package;
         $this->symbols = $symbols ?? new SymbolList();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

### Changes

This PR adds a nullable typehint to an existing type to avoid deprecation notices with PHP 8.4.