### PR TITLE
Add a compact formatter

### DIFF
--- a/src/Console/Command/UnusedCommand.php
+++ b/src/Console/Command/UnusedCommand.php
@@ -85,7 +85,7 @@ final class UnusedCommand extends Command
             'output-format',
             'o',
             InputOption::VALUE_REQUIRED,
-            'Change output style (default, github, json, junit, gitlab)'
+            'Change output style (default, compact, github, json, junit, gitlab)'
         );
 
         $this->addOption(

--- a/src/OutputFormatter/CompactFormatter.php
+++ b/src/OutputFormatter/CompactFormatter.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\OutputFormatter;
+
+use ComposerUnused\ComposerUnused\Dependency\DependencyCollection;
+use ComposerUnused\ComposerUnused\Filter\FilterCollection;
+use ComposerUnused\Contracts\PackageInterface;
+use Symfony\Component\Console\Style\OutputStyle;
+
+/**
+ * Only write a line with unused packages and a line with zombie exclusions if applicable
+ * The formatter thus only prints errors and in a compact manner
+ */
+final class CompactFormatter implements OutputFormatterInterface
+{
+    public function formatOutput(
+        PackageInterface $rootPackage,
+        string $composerJsonPath,
+        DependencyCollection $usedDependencyCollection,
+        DependencyCollection $unusedDependencyCollection,
+        DependencyCollection $ignoredDependencyCollection,
+        FilterCollection $filterCollection,
+        OutputStyle $output
+    ): int {
+        $unused = [];
+        foreach ($unusedDependencyCollection as $dependency) {
+            $unused[] = $dependency->getName();
+        }
+        if (count($unused) > 0) {
+            $output->text(sprintf('Unused packages: %s', implode(', ', $unused)));
+        }
+
+        $zombies = [];
+        foreach ($filterCollection->getUnused() as $filter) {
+            $zombies[] = $filter->toString();
+        }
+        if (count($zombies) > 0) {
+            $output->text(sprintf('Zombie exclusions: %s', implode(' / ', $zombies)));
+        }
+
+        if ($unusedDependencyCollection->count() > 0 || count($filterCollection->getUnused()) > 0) {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/OutputFormatter/FormatterFactory.php
+++ b/src/OutputFormatter/FormatterFactory.php
@@ -33,6 +33,8 @@ final class FormatterFactory
         }
 
         switch ($type) {
+            case 'compact':
+                return new CompactFormatter();
             case 'github':
                 return new GithubFormatter();
             case 'json':

--- a/tests/Unit/OutputFormatter/CompactFormatter/CompactFormatterTest.php
+++ b/tests/Unit/OutputFormatter/CompactFormatter/CompactFormatterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Test\Unit\OutputFormatter\CompactFormatter;
+
+use ComposerUnused\ComposerUnused\Composer\Package;
+use ComposerUnused\ComposerUnused\Configuration\NamedFilter;
+use ComposerUnused\ComposerUnused\Dependency\DependencyCollection;
+use ComposerUnused\ComposerUnused\Dependency\RequiredDependency;
+use ComposerUnused\ComposerUnused\Filter\FilterCollection;
+use ComposerUnused\ComposerUnused\OutputFormatter\CompactFormatter;
+use ComposerUnused\ComposerUnused\Test\Stubs\TestDependency;
+use ComposerUnused\Contracts\PackageInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class CompactFormatterTest extends TestCase
+{
+    private CompactFormatter $compactFormatter;
+
+    protected function setUp(): void
+    {
+        $this->compactFormatter = new CompactFormatter();
+    }
+
+    /**
+     * @test
+     */
+    public function itPrints(): void
+    {
+        $symfonyStringRequiredDependency = new RequiredDependency(
+            new Package('symfony/string'),
+        );
+        $symfonyStringRequiredDependency->requiredBy(new TestDependency('symfony/event-dispatcher'));
+        $usedDependencyCollection = new DependencyCollection([$symfonyStringRequiredDependency]);
+
+        $unusedDependencyCollection = new DependencyCollection([
+            new RequiredDependency(new Package('symfony/console'))
+        ]);
+
+        $bufferedOutput = new BufferedOutput();
+        $outputStyle = new SymfonyStyle(new ArgvInput(), $bufferedOutput);
+
+        $returnStatus = $this->compactFormatter->formatOutput(
+            $this->createMock(PackageInterface::class),
+            'composer.json',
+            $usedDependencyCollection,
+            $unusedDependencyCollection,
+            new DependencyCollection(),
+            new FilterCollection([NamedFilter::fromString('symfony/zombie')], []),
+            $outputStyle
+        );
+        $consoleOutput = $bufferedOutput->fetch();
+
+        self::assertSame(1, $returnStatus);
+        $lines = \explode(PHP_EOL, trim($consoleOutput));
+        self::assertSame('Unused packages: symfony/console', trim($lines[0]));
+        self::assertSame('Zombie exclusions: NamedFilter(userProvided: true, string: symfony/zombie)', trim($lines[1]));
+    }
+
+
+    /**
+     * @test
+     */
+    public function itPrintsNothingWhenNoErrors(): void
+    {
+        $symfonyStringRequiredDependency = new RequiredDependency(
+            new Package('symfony/string'),
+        );
+        $symfonyStringRequiredDependency->requiredBy(new TestDependency('symfony/event-dispatcher'));
+        $usedDependencyCollection = new DependencyCollection([$symfonyStringRequiredDependency]);
+
+        $bufferedOutput = new BufferedOutput();
+        $outputStyle = new SymfonyStyle(new ArgvInput(), $bufferedOutput);
+
+        $returnStatus = $this->compactFormatter->formatOutput(
+            $this->createMock(PackageInterface::class),
+            'composer.json',
+            $usedDependencyCollection,
+            new DependencyCollection([]),
+            new DependencyCollection(),
+            new FilterCollection([], []),
+            $outputStyle
+        );
+        $consoleOutput = $bufferedOutput->fetch();
+
+        self::assertSame(0, $returnStatus);
+        self::assertSame('', $consoleOutput);
+    }
+}


### PR DESCRIPTION
Add a compact formatter, that only prints single lines with errors

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/composer-unused/composer-unused/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/icanhazstring/composer-unused/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
