### PR TITLE
feat: add ConfigurationSet system for framework-specific scanning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+composer-unused is a static analysis tool that identifies unused Composer dependencies by scanning PHP code for symbol usage. It analyzes composer.json requirements against actual code usage to detect packages that can be safely removed.
+
+## Key Architecture Components
+
+### Core Analysis Flow
+1. **Symbol Collection**: `Symbol/` namespace handles building loaders for consumed and provided symbols
+2. **Dependency Resolution**: `Dependency/` manages required dependencies and collections
+3. **Composer Integration**: `Composer/` provides package analysis, local repository handling, and installed package parsing
+4. **Command Processing**: `Command/` contains CQRS-style commands and handlers for symbol collection and dependency loading
+5. **Output Formatting**: `OutputFormatter/` supports multiple output formats (default, compact, JSON, JUnit, GitHub, GitLab)
+
+### Configuration System
+- Main config via `composer-unused.php` file (see Configuration class)
+- Supports named filters (`NamedFilter`) and pattern-based filters (`PatternFilter`) for excluding packages
+- Additional file parsing can be configured per dependency
+- CLI options for excluding directories and packages
+
+### Console Commands
+- `UnusedCommand`: Main command for finding unused dependencies
+- `DebugConsumedSymbolsCommand`: Debug consumed symbols in code
+- `DebugProvidedSymbolsCommand`: Debug symbols provided by packages
+
+## Development Commands
+
+### Local Development (Docker recommended)
+```bash
+# Setup
+make up                    # Start Docker containers
+make install              # Install dependencies
+make clean                # Clean vendor/ and composer.lock
+
+# Testing and Quality
+make check                # Run all checks (cs, analyse, phpunit)
+make phpunit              # Run PHPUnit tests
+make analyse              # Run PHPStan analysis  
+make cs                   # Run PHP CodeSniffer
+make csfix                # Fix coding standards
+
+# Building
+make box                  # Compile PHAR archive
+```
+
+### Composer Scripts
+```bash
+composer test             # Run PHPUnit tests
+composer analyse          # Run PHPStan analysis (level 8)
+composer cs-check         # Check coding standards
+composer cs-fix           # Fix coding standards automatically
+composer check            # Run all quality checks
+```
+
+### Testing
+- PHPUnit configuration in `phpunit.xml`
+- Tests organized in `tests/Integration/` and `tests/Unit/`
+- Test assets in `tests/assets/TestProjects/` for integration testing
+- Run specific test suites: `vendor/bin/phpunit --testsuite=unit`
+
+### Static Analysis
+- PHPStan level 8 with configuration in `phpstan.neon`
+- Baseline file: `phpstan-baseline.neon`
+- Excludes test assets directory from analysis
+
+### Code Standards
+- PHP_CodeSniffer configuration in `phpcs.xml`
+- Parallel processing with caching enabled
+- Use `composer cs-fix` to automatically fix most issues
+
+## Key Implementation Notes
+
+### Symbol Parser Integration
+Uses `composer-unused/symbol-parser` for PHP code analysis and symbol extraction.
+
+### Composer Version Support
+- Requires `composer-runtime-api: ^2.0`
+- Handles different installed.json formats via `SupportedInstalledPackagesVersionChecker`
+
+### Package Resolution
+- `PackageResolver` manages dependency resolution logic
+- `LocalRepository` and `LocalRepositoryFactory` handle local package analysis
+- Special handling for packages without proper autoload configuration
+
+### Output Flexibility
+Multiple output formatters support different CI/CD integrations and development workflows.
+
+## Build Process
+
+The project supports building a PHAR archive using Box:
+- Configuration in `box.json`
+- Scoped dependencies to avoid conflicts
+- GPG signing for distribution

--- a/README.md
+++ b/README.md
@@ -90,6 +90,50 @@ $config->addPatternFilter(PatternFilter::fromString('/dependency\/name/'));
 
 > You can ignore multiple dependencies by a single organization using `PatternFilter` e.g. `/symfony\/.*/`
 
+#### Configuration Sets
+For common framework setups, you can use predefined configuration sets that automatically configure additional scan paths:
+
+```php
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationSet\SymfonyConfigurationSet;
+
+$composerJson = json_decode(file_get_contents(__DIR__ . '/composer.json'), true);
+$rootPackageName = $composerJson['name'] ?? 'root';
+
+$config->applyConfigurationSet(new SymfonyConfigurationSet($rootPackageName));
+```
+
+**Available Configuration Sets:**
+- **SymfonyConfigurationSet**: Automatically scans `bin/`, `config/`, `public/`, `assets/`, and `migrations/` directories for Symfony projects
+
+See [examples/symfony-composer-unused.php](examples/symfony-composer-unused.php) for a complete example.
+
+#### Creating Custom Configuration Sets
+You can create your own configuration sets by implementing the `ConfigurationSetInterface`:
+
+```php
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationSetInterface;
+
+final class MyFrameworkConfigurationSet implements ConfigurationSetInterface
+{
+    public function apply(Configuration $configuration): Configuration
+    {
+        // Add your custom configuration logic here
+        return $configuration;
+    }
+
+    public function getName(): string
+    {
+        return 'my-framework';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Custom configuration for My Framework';
+    }
+}
+```
+
 #### Additional files to be parsed
 Per default, `composer-unused` is using the `composer.json` autoload directive to determine where to look for files to parse.
 Sometimes dependencies don't have their composer.json correctly set up, or files get loaded in another way.

--- a/examples/symfony-composer-unused.php
+++ b/examples/symfony-composer-unused.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationSet\SymfonyConfigurationSet;
+
+return static function (Configuration $config): Configuration {
+    // Apply Symfony configuration set to scan additional directories
+    $config->applyConfigurationSet(new SymfonyConfigurationSet('__root__'));
+
+    return $config;
+};

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -81,4 +81,9 @@ final class Configuration
     {
         return $this->dependenciesDir;
     }
+
+    public function applyConfigurationSet(ConfigurationSetInterface $configurationSet): self
+    {
+        return $configurationSet->apply($this);
+    }
 }

--- a/src/Configuration/ConfigurationSet/SymfonyConfigurationSet.php
+++ b/src/Configuration/ConfigurationSet/SymfonyConfigurationSet.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Configuration\ConfigurationSet;
+
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationSetInterface;
+use Webmozart\Glob\Glob;
+
+final class SymfonyConfigurationSet implements ConfigurationSetInterface
+{
+    private string $projectRoot;
+    private string $rootPackageName;
+
+    public function __construct(string $rootPackageName, string $projectRoot = '.')
+    {
+        $this->rootPackageName = $rootPackageName;
+        $this->projectRoot = rtrim($projectRoot, '/');
+    }
+
+    public function apply(Configuration $configuration): Configuration
+    {
+        $symfonyFiles = $this->getSymfonyFiles();
+
+        if (empty($symfonyFiles)) {
+            return $configuration;
+        }
+
+        // Add additional files for the root package (current project)
+        $existingFiles = $configuration->getAdditionalFilesFor($this->rootPackageName);
+        if (empty($existingFiles)) {
+            $configuration->setAdditionalFilesFor($this->rootPackageName, $symfonyFiles);
+        }
+
+        return $configuration;
+    }
+
+    public function getName(): string
+    {
+        return 'symfony';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Adds common Symfony project directories (bin/, config/, public/, assets/, migrations/) for symbol scanning';
+    }
+
+    /**
+     * Get all PHP files from Symfony directories
+     *
+     * @return array<string>
+     */
+    private function getSymfonyFiles(): array
+    {
+        $allFiles = [];
+        $symfonyDirs = [
+            'bin',        // Console commands and executables
+            'config',     // Configuration files that may use dependencies
+            'public',     // Web entry point (index.php)
+            'assets',     // Frontend assets (may contain PHP)
+            'migrations', // Database migrations
+        ];
+
+        foreach ($symfonyDirs as $dir) {
+            $dirPath = $this->projectRoot . '/' . $dir;
+            if (is_dir($dirPath)) {
+                $phpFiles = Glob::glob($dirPath . '/**/*.php');
+                $allFiles = array_merge($allFiles, $phpFiles);
+            }
+        }
+
+        // Add bin/console directly (doesn't have .php extension)
+        $consolePath = $this->projectRoot . '/bin/console';
+        if (file_exists($consolePath)) {
+            $allFiles[] = $consolePath;
+        }
+
+        return $allFiles;
+    }
+}

--- a/src/Configuration/ConfigurationSetInterface.php
+++ b/src/Configuration/ConfigurationSetInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Configuration;
+
+interface ConfigurationSetInterface
+{
+    public function apply(Configuration $configuration): Configuration;
+
+    public function getName(): string;
+
+    public function getDescription(): string;
+}

--- a/tests/Unit/Configuration/ConfigurationSet/SymfonyConfigurationSetTest.php
+++ b/tests/Unit/Configuration/ConfigurationSet/SymfonyConfigurationSetTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComposerUnused\ComposerUnused\Test\Unit\Configuration\ConfigurationSet;
+
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationSet\SymfonyConfigurationSet;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+
+final class SymfonyConfigurationSetTest extends TestCase
+{
+    private vfsStreamDirectory $vfsRoot;
+
+    protected function setUp(): void
+    {
+        $this->vfsRoot = vfsStream::setup('project');
+    }
+
+    public function testApplyAddsSymfonyDirectoriesToConfiguration(): void
+    {
+        // Create a mock Symfony project structure
+        vfsStream::create([
+            'bin' => [
+                'console' => '<?php // console file'
+            ],
+            'config' => [
+                'services.yaml' => 'services: []',
+                'packages' => [
+                    'framework.yaml' => 'framework: []'
+                ]
+            ],
+            'public' => [
+                'index.php' => '<?php // entry point'
+            ],
+            'migrations' => [
+                'Version20231201000000.php' => '<?php // migration'
+            ]
+        ], $this->vfsRoot);
+
+        $configuration = new Configuration();
+        $configurationSet = new SymfonyConfigurationSet('my/project', $this->vfsRoot->url());
+
+        $result = $configurationSet->apply($configuration);
+
+        $additionalFiles = $result->getAdditionalFilesFor('my/project');
+
+        $this->assertNotEmpty($additionalFiles);
+        $this->assertContains($this->vfsRoot->url() . '/bin/console', $additionalFiles);
+        $this->assertContains($this->vfsRoot->url() . '/public/index.php', $additionalFiles);
+        $this->assertContains($this->vfsRoot->url() . '/migrations/Version20231201000000.php', $additionalFiles);
+    }
+
+    public function testApplyDoesNotOverrideExistingAdditionalFiles(): void
+    {
+        vfsStream::create([
+            'bin' => [
+                'console' => '<?php // console file'
+            ]
+        ], $this->vfsRoot);
+
+        $configuration = new Configuration();
+        $configuration->setAdditionalFilesFor('my/project', ['/existing/file.php']);
+
+        $configurationSet = new SymfonyConfigurationSet('my/project', $this->vfsRoot->url());
+        $result = $configurationSet->apply($configuration);
+
+        $additionalFiles = $result->getAdditionalFilesFor('my/project');
+
+        $this->assertEquals(['/existing/file.php'], $additionalFiles);
+    }
+
+    public function testApplyWithNonExistentDirectories(): void
+    {
+        // No directories created - project root is empty
+        $configuration = new Configuration();
+        $configurationSet = new SymfonyConfigurationSet('my/project', $this->vfsRoot->url());
+
+        $result = $configurationSet->apply($configuration);
+
+        $additionalFiles = $result->getAdditionalFilesFor('my/project');
+        $this->assertEmpty($additionalFiles);
+    }
+
+    public function testGetName(): void
+    {
+        $configurationSet = new SymfonyConfigurationSet('my/project');
+        $this->assertEquals('symfony', $configurationSet->getName());
+    }
+
+    public function testGetDescription(): void
+    {
+        $configurationSet = new SymfonyConfigurationSet('my/project');
+        $this->assertStringContainsString('Symfony project directories', $configurationSet->getDescription());
+    }
+}

--- a/tests/Unit/Configuration/ConfigurationTest.php
+++ b/tests/Unit/Configuration/ConfigurationTest.php
@@ -6,6 +6,7 @@ namespace ComposerUnused\ComposerUnused\Test\Unit\Configuration;
 
 use ComposerUnused\ComposerUnused\Configuration\AdditionalFilesAlreadySetException;
 use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\ConfigurationSetInterface;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
@@ -34,5 +35,23 @@ class ConfigurationTest extends TestCase
         self::expectException(AdditionalFilesAlreadySetException::class);
         self::expectExceptionMessage('You already added files for test/dependency. Did you want to add multiple files? Try adding these via multiple globs.');
         $config->setAdditionalFilesFor('test/dependency', ['file2.php']);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldApplyConfigurationSet(): void
+    {
+        $config = new Configuration();
+
+        $configurationSet = $this->createMock(ConfigurationSetInterface::class);
+        $configurationSet->expects($this->once())
+            ->method('apply')
+            ->with($config)
+            ->willReturn($config);
+
+        $result = $config->applyConfigurationSet($configurationSet);
+
+        $this->assertSame($config, $result);
     }
 }


### PR DESCRIPTION
Enables predefined configuration sets for common frameworks to automatically scan additional directories beyond src/. Improves accuracy for Symfony projects by including bin/, config/, public/, assets/, and migrations/ directories where dependencies are commonly used but previously missed.
