### PR TITLE
fix: automatically disable XDebug to prevent segmentation faults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,10 +71,30 @@ composer check            # Run all quality checks
 - Parallel processing with caching enabled
 - Use `composer cs-fix` to automatically fix most issues
 
+### Git Commit Standards
+- **ALWAYS use conventional commits** following the format: `type(scope): description`
+- **DO NOT include AI attribution** in commit messages (no "Generated with Claude Code" or "Co-Authored-By: Claude")
+- Keep commit messages concise and descriptive
+- Use these conventional commit types:
+  - `feat:` - New features
+  - `fix:` - Bug fixes
+  - `docs:` - Documentation changes
+  - `style:` - Code formatting changes
+  - `refactor:` - Code refactoring
+  - `test:` - Test additions or changes
+  - `chore:` - Maintenance tasks
+
+Conventional commits provide consistent history, enable automated changelog generation, and make it easier to understand the impact of changes. They also integrate well with semantic versioning and CI/CD workflows.
+
 ## Key Implementation Notes
 
 ### Symbol Parser Integration
 Uses `composer-unused/symbol-parser` for PHP code analysis and symbol extraction.
+
+### XDebug Compatibility
+- Automatically disables XDebug on startup using `composer/xdebug-handler` for optimal performance
+- Users can override with `COMPOSER_UNUSED_ALLOW_XDEBUG=1` environment variable
+- Prevents segmentation faults and performance issues with XDebug 3.4.3+
 
 ### Composer Version Support
 - Requires `composer-runtime-api: ^2.0`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Having `composer-unused` as a local dependency you can run it using the shipped 
 
     vendor/bin/composer-unused
 
+### XDebug Performance
+For optimal performance, `composer-unused` automatically disables XDebug when it's running to avoid memory overhead and potential compatibility issues. 
+
+If you need to debug `composer-unused` itself or run it with XDebug enabled, you can set the `COMPOSER_UNUSED_ALLOW_XDEBUG=1` environment variable:
+
+    COMPOSER_UNUSED_ALLOW_XDEBUG=1 php composer-unused.phar
 
 ### Exclude folders and packages
 Sometimes you don't want to scan a certain directory or ignore a Composer package while scanning.

--- a/bin/composer-unused
+++ b/bin/composer-unused
@@ -4,6 +4,7 @@
 use ComposerUnused\ComposerUnused\Console\Command\DebugConsumedSymbolsCommand;
 use ComposerUnused\ComposerUnused\Console\Command\DebugProvidedSymbolsCommand;
 use ComposerUnused\ComposerUnused\Console\Command\UnusedCommand;
+use Composer\XdebugHandler\XdebugHandler;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -35,6 +36,11 @@ use Symfony\Component\Console\Input\ArgvInput;
     }
 
     require UNUSED_COMPOSER_INSTALL;
+
+    // Restart process without XDebug if it's enabled (unless explicitly allowed)
+    $xdebug = new XdebugHandler('COMPOSER_UNUSED');
+    $xdebug->check();
+    unset($xdebug);
 
     /** @var ContainerInterface $container */
     $container = require __DIR__ . '/../config/container.php';

--- a/composer-unused.php
+++ b/composer-unused.php
@@ -13,6 +13,7 @@ return static function (Configuration $config): Configuration {
         // ->addPatternFilter(PatternFilter::fromString('/symfony\/.*/'))
         ->setAdditionalFilesFor('icanhazstring/composer-unused', [
             __FILE__,
+            'bin/composer-unused',
             ...Glob::glob(__DIR__ . '/config/*.php'),
         ]);
 

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "composer-runtime-api": "^2.0",
         "composer-unused/contracts": "^0.3",
         "composer-unused/symbol-parser": "^0.3.1",
+        "composer/xdebug-handler": "^3.0",
         "nikic/php-parser": "^5.0",
         "ondram/ci-detector": "^4.1",
         "phpstan/phpdoc-parser": "^1.25 || ^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f554ea0fe2ff08f222a613f41efb630",
+    "content-hash": "4d0be31cda4d3faecf1c7a8be043d017",
     "packages": [
         {
             "name": "composer-unused/contracts",
@@ -122,6 +122,151 @@
                 }
             ],
             "time": "2025-03-19T09:13:50+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
## Summary
- Integrates `composer/xdebug-handler` to automatically disable XDebug when composer-unused runs
- Prevents segmentation faults that occur with XDebug 3.4.3 and certain method chaining syntax patterns
- Provides transparent performance improvement for all users with XDebug installed
- Allows users to override with `COMPOSER_UNUSED_ALLOW_XDEBUG=1` environment variable when debugging is needed

## Changes
- Added `composer/xdebug-handler` dependency
- Integrated XDebug handler in main entry point (`bin/composer-unused`)
- Updated documentation (README.md and CLAUDE.md) with XDebug handling information
- Added conventional commit standards to CLAUDE.md

## Testing
- ✅ Coding standards check passes
- ✅ PHPStan analysis passes
- ✅ No breaking changes to existing functionality

## Closes
Fixes #688

## Additional Context
This solution follows the industry standard approach used by Composer itself and other major PHP tools (PHPStan, Psalm, etc.) for handling XDebug performance and compatibility issues.